### PR TITLE
bfs_option default is now True

### DIFF
--- a/graph2tac/loader/data_server.py
+++ b/graph2tac/loader/data_server.py
@@ -500,7 +500,7 @@ class DataServer:
                  work_dir: Path = Path('.'),
                  split: tuple[int] = (8, 1, 1),
                  cross_valid_fold: int = 0,
-                 bfs_option = False,
+                 bfs_option = True,
                  max_subgraph_size: int = 20000,
                  split_random_seed = 0,
                  num_proc = None,


### PR DESCRIPTION
seems semantically more meaningful to cut out large graphs by depth level since graph neural network operates at finite depth 