### PR TITLE
Fix bug in Predict.initialize, update loader output format

### DIFF
--- a/graph2tac/tfgnn/dataset.py
+++ b/graph2tac/tfgnn/dataset.py
@@ -241,14 +241,17 @@ class Dataset:
         # applying symmetrization
         edge_label_num = self._graph_constants.edge_label_num
         if self.symmetrization == UNDIRECTED:
-            dataset = dataset.map(lambda graph_tensor: self._symmetrize(graph_tensor, edge_label_num, True))
+            dataset = dataset.map(lambda graph_tensor: self._symmetrize(graph_tensor, edge_label_num, True),
+                                  num_parallel_calls=tf.data.AUTOTUNE)
         elif self.symmetrization == BIDIRECTIONAL:
-            dataset = dataset.map(lambda graph_tensor: self._symmetrize(graph_tensor, edge_label_num, False))
+            dataset = dataset.map(lambda graph_tensor: self._symmetrize(graph_tensor, edge_label_num, False),
+                                  num_parallel_calls=tf.data.AUTOTUNE)
             edge_label_num *= 2
 
         # introducing self edges
         if self.add_self_edges:
-            dataset = dataset.map(lambda graph_tensor: self._add_self_edges(graph_tensor, edge_label_num))
+            dataset = dataset.map(lambda graph_tensor: self._add_self_edges(graph_tensor, edge_label_num),
+                                  num_parallel_calls=tf.data.AUTOTUNE)
 
         # shuffling
         if shuffle:
@@ -449,7 +452,8 @@ class TFRecordDataset(Dataset):
         dataset = tf.data.TFRecordDataset(filenames=[str(tfrecord_filepath.absolute())])
 
         # parse it into GraphTensor objects
-        dataset = dataset.map(lambda graph_tensor: tfgnn.parse_single_example(graph_spec, graph_tensor))
+        dataset = dataset.map(lambda graph_tensor: tfgnn.parse_single_example(graph_spec, graph_tensor),
+                              num_parallel_calls=tf.data.AUTOTUNE)
 
         return dataset
 

--- a/graph2tac/tfgnn/dataset.py
+++ b/graph2tac/tfgnn/dataset.py
@@ -63,19 +63,19 @@ class Dataset:
         """
         Returns the training proof-state dataset.
         """
-        return self._preprocess(self._train_proofstates(), shuffle=shuffle)
+        return self._preprocess(self._train_proofstates(), shuffle=shuffle).cache()
 
     def valid_proofstates(self, shuffle: bool = True) -> tf.data.Dataset:
         """
         Returns the validation proof-state dataset.
         """
-        return self._preprocess(self._valid_proofstates(), shuffle=shuffle)
+        return self._preprocess(self._valid_proofstates(), shuffle=shuffle).cache()
 
     def definitions(self, shuffle: bool = True) -> tf.data.Dataset:
         """
         Returns the definition dataset.
         """
-        return self._preprocess(self._definitions(), shuffle=shuffle)
+        return self._preprocess(self._definitions(), shuffle=shuffle).cache()
 
     def graph_constants(self) -> GraphConstants:
         """

--- a/graph2tac/tfgnn/predict.py
+++ b/graph2tac/tfgnn/predict.py
@@ -118,7 +118,12 @@ class PredictOutput:
         Evaluate an action in tuple format.
         """
         (_, _, _, _, _, context_node_ids) = self.state
-        action = DataLoaderDataset._action_to_arguments(action, len(context_node_ids))
+        local_context_length = tf.shape(context_node_ids, out_type=tf.int64)[0]
+
+        tactic_id, arguments_array = action
+        tactic_id = tf.cast(tactic_id, dtype=tf.int64)
+        arguments_array = tf.cast(arguments_array, dtype=tf.int64)
+        action = DataLoaderDataset._action_to_arguments((tactic_id, arguments_array), local_context_length)
         return self._evaluate(*action)
 
 
@@ -249,7 +254,7 @@ class Predict:
                 )
 
     def compute_new_definitions(self, new_cluster_subgraphs: List[Tuple]) -> None:
-        definition_graph = self._make_definition_dataset(new_cluster_subgraphs).batch(len(new_cluster_subgraphs)).get_single_element()
+        definition_graph = self._make_definition_batch(new_cluster_subgraphs)
 
         masked_definition_graph = Trainer._mask_defined_labels(definition_graph)
         scalar_definition_graph = masked_definition_graph.merge_batch_to_components()
@@ -265,17 +270,11 @@ class Predict:
         old_embeddings = (1 - update_mask) * self.prediction_task.graph_embedding._node_embedding.embeddings
         self.prediction_task.graph_embedding._node_embedding.set_weights([new_embeddings + old_embeddings])
 
-    def _make_dummy_proofstate_graph_tensor(self, state: Tuple) -> tfgnn.GraphTensor:
-        """
-        Create a (dummy) proofstate graph from the given proof-state (the resulting graph tensor has fake labels).
-        """
-        # action = (tactic_id, argument_ids_in_context)
-        action = (self._dummy_tactic_id, np.zeros(shape=(0,2), dtype=np.uint32))
-
-        # proofstate_data = (state, action, graph_id)
-        proofstate_data = (state, action, None)
-
-        return DataLoaderDataset._make_proofstate_graph_tensor(proofstate_data=proofstate_data)
+    def _dummy_proofstate_data_generator(self, states: List[Tuple]):
+        for state in states:
+            action = (self._dummy_tactic_id, tf.zeros(shape=(0, 2), dtype=tf.int64))
+            graph_id = tf.constant(-1, dtype=tf.int64)
+            yield state, action, graph_id
 
     def _make_dummy_proofstate_dataset(self, states: List[Tuple]) -> tf.data.Dataset:
         """
@@ -284,24 +283,24 @@ class Predict:
         @param states: list of proof-states in tuple form (as returned by the data loader)
         @return: a `tf.data.Dataset` producing `GraphTensor` objects following the `proofstate_graph_spec` schema
         """
-        dataset = tf.data.Dataset.from_generator(lambda: map(self._make_dummy_proofstate_graph_tensor, states),
-                                                 output_signature=proofstate_graph_spec)
+        dataset = tf.data.Dataset.from_generator(lambda: self._dummy_proofstate_data_generator(states),
+                                                 output_signature=DataLoaderDataset.proofstate_data_spec)
+        dataset = dataset.map(DataLoaderDataset._make_proofstate_graph_tensor)
         dataset = self._preprocess(dataset, shuffle=False)
         return dataset
 
-    def _make_definition_dataset(self, new_cluster_subgraphs: List[Tuple]) -> tf.data.Dataset:
+    def _make_definition_batch(self, new_cluster_subgraphs: List[Tuple]) -> tfgnn.GraphTensor:
         """
         Create a dataset of definition graphs.
 
         @param new_cluster_subgraphs: list of definition clusters in tuple form (as returned by the data loader)
-        @return: a `tf.data.Dataset` producing `GraphTensor` objects following the `definition_graph_spec` schema
+        @return: a `GraphTensor` containing the definition clusters, following the `definition_graph_spec` schema
         """
-        dataset = tf.data.Dataset.from_generator(
-            lambda: map(DataLoaderDataset._make_definition_graph_tensor, new_cluster_subgraphs),
-            output_signature=definition_graph_spec)
-
+        dataset = tf.data.Dataset.from_generator(lambda: new_cluster_subgraphs,
+                                                 output_signature=DataLoaderDataset.definition_data_spec)
+        dataset = dataset.map(DataLoaderDataset._make_definition_graph_tensor)
         dataset = self._preprocess(dataset, shuffle=False)
-        return dataset
+        return dataset.batch(len(new_cluster_subgraphs)).get_single_element()
 
     @staticmethod
     def _logits_decoder(logits: tf.Tensor, total_expand_bound: int) -> Tuple[np.ndarray, np.ndarray]:


### PR DESCRIPTION
This branch incorporates Vasily's latest changes to the output format of the data server, and fixes a bug in Predict.initialize which may or may not solve the issue with local argument predictions being suppressed