### PR TITLE
Added TF-GNN requirements and entry points to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
                   [
                       'g2t-preprocess=graph2tac.loader.preprocess:main',
                       'g2t-train=graph2tac.tf2.train:main',
+                      'g2t-train-tfgnn=graph2tac.tfgnn.train:main',
                       'g2t-stat=graph2tac.loader.graph_stat:main',
                       'g2t-printlog=graph2tac.printlog:main',
                       'g2t-unpack=graph2tac.loader.unpack:main',
@@ -102,6 +103,7 @@ setup(
     install_requires=[
         'keras>=2.8',
         'tensorflow>=2.8',
+        'tensorflow_gnn>=0.2.0.dev1'
         'fire',
         'pycapnp',
         'psutil',

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     install_requires=[
         'keras>=2.8',
         'tensorflow>=2.8',
-        'tensorflow_gnn>=0.2.0.dev1'
+        'tensorflow_gnn>=0.2.0.dev1',
         'fire',
         'pycapnp',
         'psutil',


### PR DESCRIPTION
- Added g2t-trian-tfgnn entry point to train TF-GNN models
- Added tensorflow_gnn>=0.2.0.dev1 to setup.py
- Checked installation works in Windows + WSL 2 (Ubuntu 20.04), clean Ubuntu 22..04 and PaperSpace Ubuntu 20.04 with multiple GPUs