### PR TITLE
Improve the handling of batches with no arguments in both `LocalArgumentTask` and `GlobalArgumentTask`

### DIFF
--- a/graph2tac/tfgnn/train.py
+++ b/graph2tac/tfgnn/train.py
@@ -195,9 +195,6 @@ class Trainer:
         # batching
         dataset = dataset.batch(self.batch_size)
 
-        # filtering
-        dataset = dataset.filter(self.prediction_task.batch_filter)
-
         return dataset
 
     def _l2_regularization(self):


### PR DESCRIPTION
Any arguments head can now avoid handling batches with no arguments by inheriting from `ArgumentsHead` and implementing in `_get_hidden_state_sequences ` what would otherwise go to the `tf.keras.layers.Layer.call` method.

This change has been (lightly) tested and should be non-breaking; @mirefek can you make sure it does not conflict with any of your WIP?