### PR TITLE
Adopted the logging module for log messages

### DIFF
--- a/graph2tac/common.py
+++ b/graph2tac/common.py
@@ -1,6 +1,8 @@
 import os, glob
 import capnp
 import hashlib
+import logging
+import sys
 from pathlib import Path
 """
 
@@ -45,3 +47,9 @@ def uuid(data_dir: Path):
     m = hashlib.md5()
     m.update(os.fsencode(data_dir.expanduser().resolve()))
     return m.hexdigest()[:6]
+
+logger = logging.getLogger('graph2tac')
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('%(name)s:%(levelname)s - %(message)s'))
+logger.addHandler(handler)

--- a/graph2tac/tfgnn/predict.py
+++ b/graph2tac/tfgnn/predict.py
@@ -14,6 +14,7 @@ from graph2tac.tfgnn.dataset import Dataset, DataServerDataset
 from graph2tac.tfgnn.tasks import PredictionTask, GlobalArgumentPrediction, DefinitionTask, BASE_TACTIC_PREDICTION, LOCAL_ARGUMENT_PREDICTION, GLOBAL_ARGUMENT_PREDICTION, _local_arguments_logits
 from graph2tac.tfgnn.models import GraphEmbedding, LogitsFromEmbeddings
 from graph2tac.tfgnn.train import Trainer
+from graph2tac.common import logger
 
 
 NUMPY_NDIM_LIMIT = 32
@@ -191,11 +192,11 @@ class Predict:
         try:
             checkpoint_restored = checkpoint_manager.restore_or_initialize()
         except tf.errors.NotFoundError as error:
-            print(f'unable to restore checkpoint from {checkpoint_path}!')
+            logger.error(f'unable to restore checkpoint from {checkpoint_path}!')
             raise error
         else:
             if checkpoint_restored is not None:
-                print(f'restored checkpoint {checkpoint_restored}!')
+                logger.info(f'restored checkpoint {checkpoint_restored}!')
 
         # choose the prediction method according to the task type
         prediction_task_type = self.prediction_task.get_config().get('prediction_task_type')

--- a/graph2tac/tfgnn/train.py
+++ b/graph2tac/tfgnn/train.py
@@ -12,6 +12,7 @@ from graph2tac.tfgnn.dataset import Dataset, DataServerDataset, TFRecordDataset
 from graph2tac.tfgnn.tasks import PredictionTask, DefinitionTask, DefinitionMeanSquaredError
 from graph2tac.tfgnn.graph_schema import definition_graph_spec, batch_graph_spec
 from graph2tac.tfgnn.q_checkpoint_manager import QCheckpointManager
+from graph2tac.common import logger
 
 
 class Trainer:
@@ -162,11 +163,11 @@ class Trainer:
             try:
                 checkpoint_restored = checkpoint_manager.restore_or_initialize()
             except tf.errors.NotFoundError as error:
-                print(f'unable to restore checkpoint from {checkpoint_path}!')
+                logger.error(f'unable to restore checkpoint from {checkpoint_path}!')
                 raise error
             else:
                 if checkpoint_restored is not None:
-                    print(f'Restored checkpoint {checkpoint_restored}!')
+                    logger.info(f'Restored checkpoint {checkpoint_restored}!')
 
             save_checkpoint_callback = tf.keras.callbacks.LambdaCallback(on_epoch_end=lambda epoch, logs: checkpoint_manager.save())
             callbacks.append(save_checkpoint_callback)
@@ -346,7 +347,14 @@ def main():
     # device specification
     parser.add_argument("--gpu", type=str,
                         help="GPUs to use for training ('/gpu:0', '/gpu:1', ... or use 'all' for multi-GPU training)")
+
+    # logging level
+    parser.add_argument("--log-level", type=int, metavar="LOG_LEVEL", default=20,
+                        help="Logging level (defaults to 20, a.k.a. logging.INFO)")
     args = parser.parse_args()
+
+    # set logging level
+    logger.setLevel(args.log_level)
 
     # read the run parameters and set the global seed
     if not args.run_config.is_file():


### PR DESCRIPTION
Ideally we should later migrate all logging functionality to use the `graph2tac.common` logger, then we can control verbosity levels and logging destinations with a single switch.

Signed-off-by: Fidel I. Schaposnik Massolo <fidel.s@gmail.com>