### PR TITLE
Fidels/fix cpu mode

### DIFF
--- a/graph2tac/tfgnn/predict.py
+++ b/graph2tac/tfgnn/predict.py
@@ -242,10 +242,11 @@ class TFGNNPredict(Predict):
             )
 
     def compute_new_definitions(self, new_cluster_subgraphs: List[Tuple]) -> None:
+        if self.definition_task is None:
+            raise RuntimeError('cannot update definitions when a definition task is not present')
         definition_graph = self._make_definition_batch(new_cluster_subgraphs)
 
-        masked_definition_graph = Trainer._mask_defined_labels(definition_graph)
-        scalar_definition_graph = masked_definition_graph.merge_batch_to_components()
+        scalar_definition_graph = definition_graph.merge_batch_to_components()
         definition_embeddings = self.definition_task(scalar_definition_graph).flat_values
         defined_labels = Trainer._get_defined_labels(definition_graph).flat_values
 

--- a/graph2tac/tfgnn/train.py
+++ b/graph2tac/tfgnn/train.py
@@ -262,8 +262,7 @@ class Trainer:
 
         # compute definition body embeddings
         definition_graph = tf.keras.layers.Input(type_spec=batch_graph_spec(definition_graph_spec))
-        masked_definition_graph = self._mask_defined_labels(definition_graph)
-        scalar_definition_graph = masked_definition_graph.merge_batch_to_components()
+        scalar_definition_graph = definition_graph.merge_batch_to_components()
         definition_body_embeddings = self.definition_task(scalar_definition_graph)  # noqa [ PyCallingNonCallable ]
 
         # get learned definition embeddings

--- a/graph2tac/tfgnn/train.py
+++ b/graph2tac/tfgnn/train.py
@@ -241,15 +241,6 @@ class Trainer:
         return tf.reduce_sum([tf.keras.regularizers.l2(l2=self.l2_regularization_coefficient)(weight) for weight in self.train_model.trainable_weights])
 
     @staticmethod
-    def _mask_defined_labels(definition_graph: tfgnn.GraphTensor) -> tfgnn.GraphTensor:
-        num_definitions = tf.cast(definition_graph.context['num_definitions'], dtype=tf.int32)
-        is_defined = tf.ragged.range(tf.squeeze(definition_graph.node_sets['node'].sizes, axis=-1)) < num_definitions
-        masked_node_labels = tf.where(is_defined.with_row_splits_dtype(tf.int32),
-                                      tf.constant(-1, dtype=tf.int64),  # TODO: This fails on CPU
-                                      definition_graph.node_sets['node']['node_label'])
-        return definition_graph.replace_features(node_sets={'node': {'node_label': masked_node_labels}})
-
-    @staticmethod
     def _get_defined_labels(definition_graph: tfgnn.GraphTensor) -> tf.Tensor:
         cumulative_sizes = tf.cumsum(definition_graph.node_sets['node'].sizes, exclusive=True)
         definition_nodes = tf.ragged.range(tf.squeeze(definition_graph.context['num_definitions'], axis=-1)) + tf.cast(cumulative_sizes, dtype=tf.int64)


### PR DESCRIPTION
Changed the way definition ids are masked so as to not rely on the tf.keras.layers.Embedding layer's special behavior on GPU (outputs zero on invalid indices instead of raising an error)