### PR TITLE
Fidels/toplevel predict debug mode

### DIFF
--- a/graph2tac/loader/hmodel.py
+++ b/graph2tac/loader/hmodel.py
@@ -100,11 +100,11 @@ class Train:
 
 
 class HPredict(Predict):
-    def __init__(self, checkpoint_dir: Path):
+    def __init__(self, checkpoint_dir: Path, debug_dir: Optional[Path] = None):
         loaded_model = pickle.load(open(checkpoint_dir/'hmodel.sav', 'rb'))
 
         # initialize self._graph_constants
-        super().__init__(graph_constants=loaded_model['graph_constants'])
+        super().__init__(graph_constants=loaded_model['graph_constants'], debug_dir=debug_dir)
 
         self._data = loaded_model['data']
         self._label_to_index = None
@@ -112,17 +112,20 @@ class HPredict(Predict):
         self._with_context = loaded_model['with_context']
         self._label_to_idx = dict()
 
+    @Predict.api_debugging('initialize')
     def initialize(self, global_context: Optional[List[int]] = None) -> None:
         if global_context is not None:
             for idx, label in enumerate(global_context):
                 self._label_to_idx[label] = idx
 
+    @Predict.api_debugging('compute_new_definitions')
     def compute_new_definitions(self, clusters: list[tuple[np.ndarray]]):
         """
         a list of cluster states on which we run dummy runs
         """
         pass
 
+    @Predict.api_debugging('ranked_predictions')
     def ranked_predictions(self, state: tuple, allowed_model_tactics: list, available_global=None, tactic_expand_bound=20, total_expand_bound=1000000, annotation="", debug=False):
         graph, root, context = state
         state_hash = my_hash_of(state, self._with_context)

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -611,7 +611,7 @@ def main():
                         help="temperature to apply to the probability distributions returned by the model")
 
     parser.add_argument('--debug-predict',
-                        type=Optional[Path],
+                        type=Path,
                         default=None,
                         help="set this flag to run TFGNNPredict in debug mode")
 

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -614,7 +614,7 @@ def main():
     parser.add_argument('--debug-predict',
                         type=Path,
                         default=None,
-                        help="set this flag to run TFGNNPredict in debug mode")
+                        help="set this flag to run Predict in debug mode")
 
 
 

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -1,7 +1,8 @@
 """
 python prediction server to interact with coq-tactician-reinforce
 """
-from typing import NewType, Optional
+from typing import NewType
+
 import sys
 import time
 import os

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -613,7 +613,6 @@ def main():
     parser.add_argument('--debug-predict',
                         type=Optional[Path],
                         default=None,
-                        action='store_true',
                         help="set this flag to run TFGNNPredict in debug mode")
 
 

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -1,7 +1,7 @@
 """
 python prediction server to interact with coq-tactician-reinforce
 """
-import typing
+from typing import NewType, Optional
 import sys
 import time
 import os
@@ -19,7 +19,7 @@ from graph2tac.predict import Predict
 from graph2tac.loader.data_server import DataServer, build_def_index, get_global_def_table
 
 
-Tactic = typing.NewType('Tactic', object)
+Tactic = NewType('Tactic', object)
 
 capnp.remove_import_hook()
 graph_api_filename = pkg_resources.resource_filename('graph2tac.loader','clib/graph_api_v11.capnp')
@@ -610,8 +610,9 @@ def main():
                         default=1.0,
                         help="temperature to apply to the probability distributions returned by the model")
 
-    parser.add_argument('--tfgnn-debug',
-                        default=False,
+    parser.add_argument('--debug-predict',
+                        type=Optional[Path],
+                        default=None,
                         action='store_true',
                         help="set this flag to run TFGNNPredict in debug mode")
 
@@ -658,9 +659,10 @@ def main():
             import tensorflow as tf
             tf.get_logger().setLevel(int(tf_log_levels[args.log_level]))
             tf.config.run_functions_eagerly(args.tf_eager)
-            from graph2tac.tf2.predict import TF2Predict
+
             logger.info("importing TF2Predict class..")
-            predict = TF2Predict(checkpoint_dir=Path(args.model).expanduser().absolute())
+            from graph2tac.tf2.predict import TF2Predict
+            predict = TF2Predict(checkpoint_dir=Path(args.model).expanduser().absolute(), debug_dir=args.debug_predict)
         elif args.arch == 'tfgnn':
             logger.info("importing tensorflow...")
             import tensorflow as tf
@@ -669,11 +671,11 @@ def main():
 
             logger.info("importing TFGNNPredict class...")
             from graph2tac.tfgnn.predict import TFGNNPredict
-            predict = TFGNNPredict(log_dir=Path(args.model).expanduser().absolute(), debug=args.tfgnn_debug)
+            predict = TFGNNPredict(log_dir=Path(args.model).expanduser().absolute(), debug_dir=args.debug_predict)
         elif args.arch == 'hmodel':
             logger.info("importing HPredict class..")
             from graph2tac.loader.hmodel import HPredict
-            predict = HPredict(checkpoint_dir=Path(args.model).expanduser().absolute())
+            predict = HPredict(checkpoint_dir=Path(args.model).expanduser().absolute(), debug_dir=args.debug_predict)
         else:
             Exception(f'the provided model architecture {args.arch} is not supported')
 

--- a/graph2tac/predict.py
+++ b/graph2tac/predict.py
@@ -76,7 +76,7 @@ class Predict:
                         pickle.dump((api_name, kwargs), pickle_jar)
                     self._debug_message_number += 1
 
-                api_call(self, **kwargs)
+                return api_call(self, **kwargs)
             return api_call_with_debug
         return decorator
 

--- a/graph2tac/predict.py
+++ b/graph2tac/predict.py
@@ -67,16 +67,16 @@ class Predict:
     @staticmethod
     def api_debugging(api_name: str):
         def decorator(api_call: Callable):
-            def api_call_with_debug(self: "Predict", **kwargs: Dict):
+            def api_call_with_debug(self: "Predict", *args: List, **kwargs: Dict):
                 if self._debug_dir is not None:
                     debug_message_file = self._run_dir / f'{self._debug_message_number}.pickle'
                     logger.debug(f'logging {api_name} call to {debug_message_file}')
 
                     with debug_message_file.open('wb') as pickle_jar:
-                        pickle.dump((api_name, kwargs), pickle_jar)
+                        pickle.dump((api_name, args, kwargs), pickle_jar)
                     self._debug_message_number += 1
 
-                return api_call(self, **kwargs)
+                return api_call(self, *args, **kwargs)
             return api_call_with_debug
         return decorator
 


### PR DESCRIPTION
This adds generic debugging functionality to the Predict class. If you call `g2t-server` with the argument `--debug-predict ABSOLUTE_PATH`, all of Predict's API calls get pickled and saved to the given directory. Note that the path needs to be absolute, or there could be some errors due to the fact that this is supposed to be run somewhere inside 
Lasse's benchmarking scripts. Also, the given ABSOLUTE_PATH directory should not exist or be empty of other directories: the idea is that to deal with parallel execution and/or restarts, each Predict instance saves its logs to a sub-directory of ABSOLUTE_PATH , numbered 1, 2, ... (this should be improved later on, if it turns out we use this functionality a lot). In summary, we can now retrace the execution of a benchmark step by step without doing an online evaluation.

(Note that g2t-server has a similar debug command to log the interactions with Coq, but it saves this data in capnproto format. The idea for this new option is to save things from the point of view of the Predict class, which is agnostic about what goes on behind the scenes)