### PR TITLE
Add tqdm and numpy to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,8 @@ setup(
         'keras>=2.8',
         'tensorflow>=2.8',
         'tensorflow_gnn>=0.2.0.dev1',
+        'tqdm',
+        'numpy',
         'fire',
         'pycapnp',
         'psutil',


### PR DESCRIPTION
Both packages are explicitly used in our code, yet they were not included in setup.py. I've added them so that IDEs don't complain.

Signed-off-by: Fidel I. Schaposnik Massolo <fidel.s@gmail.com>