### PR TITLE
Fidels/expose names

### DIFF
--- a/graph2tac/loader/data_server.py
+++ b/graph2tac/loader/data_server.py
@@ -437,7 +437,7 @@ class Data2:
     def step_label(self, data_point_idx):
         return self.get_proof_step(data_point_idx, skip_text=True).action
 
-    def def_cluster_subgraph(self, cluster_idx,  max_arg_size=None) -> Tuple[LoaderGraph, int]:
+    def def_cluster_subgraph(self, cluster_idx,  max_arg_size=None) -> Tuple[LoaderGraph, int, np.ndarray]:
         if max_arg_size is None:
             max_arg_size = self.__max_subgraph_size
 
@@ -447,8 +447,15 @@ class Data2:
 
         nodes, edges, edge_labels, edges_offset, _ , _, _, _, _ = res
 
+        base_node_label_names, _ = get_graph_constants_online()
+        label_to_names = np.array(base_node_label_names +  self.__def_index_table.idx_to_name)
+
+        num_definitions = len(def_cluster)
+        definition_labels = nodes[:num_definitions]
+        definition_names = label_to_names[definition_labels]
+
         graph = LoaderGraph( (nodes, edges, edge_labels, edges_offset) )
-        return graph, len(def_cluster)
+        return graph, num_definitions, definition_names
 
 
 class Iterator:

--- a/graph2tac/loader/data_server.py
+++ b/graph2tac/loader/data_server.py
@@ -3,7 +3,7 @@ data server provides the class to serve data to training
  - from a collection of bin files in a filesystem
  - from messages in a stream in interactive session (to be implmeneted)
 """
-from typing import List, Tuple, Callable
+from typing import List, Tuple, Callable, NewType
 
 import time
 import os
@@ -19,6 +19,8 @@ from graph2tac.hash import get_split_label
 from graph2tac.loader.helpers import get_all_fnames
 
 import tqdm
+
+LoaderGraph = NewType('LoaderGraph', Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray])
 
 
 from graph2tac.loader.clib.loader import (
@@ -58,7 +60,7 @@ class GraphConstants:
 @dataclass
 class DataPoint:
     proof_step_idx: int
-    graph: Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+    graph: LoaderGraph
     context: np.ndarray
     root: int
     action: Tuple[np.ndarray, np.ndarray]
@@ -421,7 +423,7 @@ class Data2:
 
 
     # REFACTOR CLIENTS
-    def step_state(self, data_point_idx: int):
+    def step_state(self, data_point_idx: int) -> Tuple[LoaderGraph, int, np.ndarray, Tuple]:
         proof_step = self.get_proof_step(data_point_idx, skip_text=True)
         return proof_step.graph, proof_step.root, proof_step.context, (proof_step.def_name, proof_step.step_in_proof)
 

--- a/graph2tac/loader/data_server.py
+++ b/graph2tac/loader/data_server.py
@@ -423,7 +423,7 @@ class Data2:
     # REFACTOR CLIENTS
     def step_state(self, data_point_idx: int):
         proof_step = self.get_proof_step(data_point_idx, skip_text=True)
-        return proof_step.graph, proof_step.root, proof_step.context
+        return proof_step.graph, proof_step.root, proof_step.context, (proof_step.def_name, proof_step.step_in_proof)
 
     def step_state_text(self, data_point_idx: int):
         return self.get_proof_step(data_point_idx).state_text

--- a/graph2tac/loader/data_server.py
+++ b/graph2tac/loader/data_server.py
@@ -386,7 +386,7 @@ class Data2:
 
         # TEXT ANNOTATION TO BE IMPLEMENTED
         return DataPoint(data_point_idx,
-                         graph = (nodes, edges, edge_labels, edges_offset),
+                         graph = LoaderGraph( (nodes, edges, edge_labels, edges_offset) ),
                          context = context,
                          root = root,
                          action=(tactic_index, args),
@@ -437,7 +437,7 @@ class Data2:
     def step_label(self, data_point_idx):
         return self.get_proof_step(data_point_idx, skip_text=True).action
 
-    def def_cluster_subgraph(self, cluster_idx,  max_arg_size=None):
+    def def_cluster_subgraph(self, cluster_idx,  max_arg_size=None) -> Tuple[LoaderGraph, int]:
         if max_arg_size is None:
             max_arg_size = self.__max_subgraph_size
 
@@ -447,7 +447,7 @@ class Data2:
 
         nodes, edges, edge_labels, edges_offset, _ , _, _, _, _ = res
 
-        graph = nodes, edges, edge_labels, edges_offset
+        graph = LoaderGraph( (nodes, edges, edge_labels, edges_offset) )
         return graph, len(def_cluster)
 
 

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from graph2tac.common import uuid, logger
 from graph2tac.predict import Predict
-from graph2tac.loader.data_server import DataServer, build_def_index, get_global_def_table
+from graph2tac.loader.data_server import DataServer, build_def_index, get_global_def_table, LoaderGraph, LoaderProofstate, LoaderDefinition
 
 
 Tactic = NewType('Tactic', object)
@@ -366,7 +366,7 @@ def main_loop(reader, sock, predict: Predict, debug_dir, session_idx=0,
                 cluster_graph = train_node_labels, edges, edge_labels, edges_offset
 
                 # cluster_state = (train_node_labels, edges_grouped_by_label, len(def_cluster))
-                cluster_state = (cluster_graph, len(def_cluster))
+                cluster_state = LoaderDefinition( (cluster_graph, len(def_cluster), cluster_names) )
                 # print(cluster_state)
                 predict.compute_new_definitions([cluster_state])
             t1 = time.time()
@@ -421,7 +421,7 @@ def main_loop(reader, sock, predict: Predict, debug_dir, session_idx=0,
             eval_node_labels, edges, edge_labels, edges_offset, global_visited, _, _, _, _ = res
 
             train_node_labels = map_eval_label_to_train_label[eval_node_labels]
-            edges_grouped_by_label = np.split(edges, edges_offset)
+            # edges_grouped_by_label = np.split(edges, edges_offset)
             this_encoded_root, this_encoded_context, this_context = load_msg_online(msg_data, global_visited, data_msg_idx)
 
             logger.debug(f"this encoded root {this_encoded_root}")
@@ -435,14 +435,17 @@ def main_loop(reader, sock, predict: Predict, debug_dir, session_idx=0,
             for edge_idx in range(child_start, child_stop):
                 logger.debug(f"root 0 child {msg.predict.graph.edges[edge_idx]}")
 
-            online_graph = train_node_labels, edges, edge_labels, edges_offset
+            online_graph = LoaderGraph( (train_node_labels, edges, edge_labels, edges_offset) )
+
+            # FIDEL: is this information present? For now, just fill it in with dummy data
+            dummy_proofstate_info = ('dummy_proofstate_name', -1)
 
             logger.verbose(f"online_state: {online_graph}")
 
             t0 = time.time()
 
             online_actions, online_confidences = predict.ranked_predictions(
-                (online_graph, this_encoded_root, this_encoded_context),
+                LoaderProofstate( (online_graph, this_encoded_root, this_encoded_context, dummy_proofstate_info) ),
                 tactic_expand_bound=tactic_expand_bound,
                 total_expand_bound=total_expand_bound,
                 allowed_model_tactics=allowed_model_tactics,

--- a/graph2tac/predict.py
+++ b/graph2tac/predict.py
@@ -5,7 +5,7 @@ import numpy as np
 from pathlib import Path
 
 from graph2tac.common import logger
-from graph2tac.loader.data_server import GraphConstants
+from graph2tac.loader.data_server import GraphConstants, LoaderProofstate, LoaderDefinition
 
 
 NUMPY_NDIM_LIMIT = 32
@@ -123,8 +123,8 @@ class Predict:
 
     @predict_api_debugging
     def ranked_predictions(self,
-                           state: Tuple,
-                           allowed_model_tactics: List,
+                           state: LoaderProofstate,
+                           allowed_model_tactics: List[int],
                            available_global: Optional[np.ndarray],
                            tactic_expand_bound: int,
                            total_expand_bound: int
@@ -145,7 +145,7 @@ class Predict:
         raise NotImplementedError('ranked_predictions should be implemented by sub-classes')
 
     @predict_api_debugging
-    def compute_new_definitions(self, new_cluster_subgraphs : List) -> None:
+    def compute_new_definitions(self, new_cluster_subgraphs : List[LoaderDefinition]) -> None:
         """
         [ Public API ] Updates definition embeddings using the model to process definition cluster subgraphs.
 

--- a/graph2tac/tf2/graph_nn_batch.py
+++ b/graph2tac/tf2/graph_nn_batch.py
@@ -117,7 +117,7 @@ def make_flat_batch_np(batch: list, global_context_size: int, max_arg_num: int) 
     # then you can call DataServer.data_point(data_point_id) for debug information
 
     # nodes_c, edges, roots, context = zip(*states)
-    graphs, roots, context = zip(*states)
+    graphs, roots, context, _ = zip(*states)
     nodes_c, edges = zip(* map(lambda x: graph_as("tf2", x), graphs))
 
 

--- a/graph2tac/tf2/graph_nn_batch.py
+++ b/graph2tac/tf2/graph_nn_batch.py
@@ -1,21 +1,20 @@
 """
 defines batch dataclass used by the specific gnn defined in graph_nn.py
-the classes in these module probably should be packaged together with
+the classes in these modules probably should be packaged together with
 GraphToLogits class in graph_nn
 """
+from typing import List, Tuple, Any
 
-from graph2tac.loader.data_server import graph_as
-
-from dataclasses import dataclass
-from typing import List
 import numpy as np
+from dataclasses import dataclass
+
+from graph2tac.loader.data_server import graph_as, LoaderProofstate
+from graph2tac.tf2.model_params import ModelDatasetConstants
 
 # TODO(jrute): This code is unique to the model in model.py,
 # and it now depends on the dataset constants saved with that model.
 # So we might as well move it there alongside np_to_tensor.
 # Then we can avoid writing np_to_tensor(flat_batch_np(...)) everywhere.
-from graph2tac.tf2.model_params import ModelDatasetConstants
-
 
 @dataclass
 class FlatBatchNP:
@@ -97,10 +96,13 @@ def build_padded_arguments_and_mask(args: np.array, max_arg_num: int, context_le
     b = np.full((max_arg_num - len(args),), False)
     mask = np.concatenate([a,b])
     padded_args = np.concatenate([args, tail_args], axis=0)
-    return (padded_args, mask)
+    return padded_args, mask
 
 
-def make_flat_batch_np(batch: list, global_context_size: int, max_arg_num: int) -> FlatBatchNP:
+def make_flat_batch_np(batch: List[Tuple[LoaderProofstate, Any, int]],
+                       global_context_size: int,
+                       max_arg_num: int
+                       ) -> FlatBatchNP:
     """
     max_arg_num: is the uniformized length of the list of arguments for tail padding
 

--- a/graph2tac/tf2/graph_nn_def_batch.py
+++ b/graph2tac/tf2/graph_nn_def_batch.py
@@ -70,7 +70,7 @@ def make_flat_def_batch_np(batch: list) -> FlatDefBatchNP:
     assert len(batch) > 0
     batch_size = len(batch)
     # nodes_c, edges, root_nums = zip(*batch)
-    graphs, root_nums = zip(*batch)
+    graphs, root_nums, _ = zip(*batch)
     nodes_c, edges = zip(* map(lambda x: graph_as("tf2", x), graphs))
 
 

--- a/graph2tac/tf2/graph_nn_def_batch.py
+++ b/graph2tac/tf2/graph_nn_def_batch.py
@@ -1,6 +1,6 @@
 """
 defines batch dataclass used by the specific gnn defined in graph_nn.py
-the classes in these module probably should be packaged together with
+the classes in these modules probably should be packaged together with
 GraphToLogits class in graph_nn
 """
 
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import List
 import numpy as np
 
-from graph2tac.loader.data_server import graph_as
+from graph2tac.loader.data_server import graph_as, LoaderDefinition
 
 # TODO(jrute): This code is unique to the model in model.py,
 # and it now depends on the dataset constants saved with that model.
@@ -62,7 +62,7 @@ class FlatDefBatchNP:
                 f"{num_datapoints} datapoints ")
 
 
-def make_flat_def_batch_np(batch: list) -> FlatDefBatchNP:
+def make_flat_def_batch_np(batch: List[LoaderDefinition]) -> FlatDefBatchNP:
     """
     this function forms FlatDefBatchNP of numpy arrays from a non-empty list of datapoints
     for empty input consider a function make_flat_def_batch_np_empty defined below (with different API)

--- a/graph2tac/tf2/predict.py
+++ b/graph2tac/tf2/predict.py
@@ -3,7 +3,7 @@ from typing import Optional, List, Tuple
 from pathlib import Path
 import numpy as np
 import tensorflow as tf
-from graph2tac.loader.data_server import GraphConstants
+from graph2tac.loader.data_server import GraphConstants, LoaderProofstate, LoaderDefinition
 
 from graph2tac.tf2.graph_nn_batch import make_flat_batch_np, make_flat_batch_np_empty
 from graph2tac.tf2.graph_nn_def_batch import make_flat_def_batch_np
@@ -43,7 +43,7 @@ class TF2Predict(Predict):
         super().__init__(graph_constants=graph_constants)
 
     @predict_api_debugging
-    def initialize(self, global_context: Optional[list[int]] = None) -> None:
+    def initialize(self, global_context: Optional[List[int]] = None) -> None:
         self.params = ModelWrapper.get_params_from_checkpoint(self.checkpoint_dir)
         self.dataset_consts = self.params.dataset_consts
         assert self.dataset_consts is not None
@@ -56,9 +56,7 @@ class TF2Predict(Predict):
             if node_label_num > self.dataset_consts.node_label_num:
                 self.model_wrapper.extend_embedding_table(node_label_num)
         max_args = self.dataset_consts.tactic_max_arg_num
-        self.dummy_action = (0,
-                             np.zeros([max_args, 2]),
-        )
+        self.dummy_action = (0, np.zeros([max_args, 2]),)
         self.dummy_id = 0
         self.pred_fn = self.model_wrapper.get_predict_fn()
         self.set_def_fn = self.model_wrapper.get_set_def_fn()
@@ -69,7 +67,7 @@ class TF2Predict(Predict):
         result = self.pred_fn(flat_batch)
 
     @predict_api_debugging
-    def compute_new_definitions(self, new_cluster_subgraphs : list) -> None:
+    def compute_new_definitions(self, new_cluster_subgraphs : List[LoaderDefinition]) -> None:
         """
         Public API. The client is supposed to call this method for a sequence of topologically sorted valid roots of
         cluster definitions. For simplicity, the client can always call this method with single-element batches in
@@ -81,7 +79,9 @@ class TF2Predict(Predict):
         flat_batch = np_to_tensor_def(flat_batch_np)
         self.set_def_fn(flat_batch)
 
-    def predict_tactic_logits(self, state: tuple) -> np.ndarray:  # [tactics]
+    def predict_tactic_logits(self,
+                              state: LoaderProofstate
+                              ) -> np.ndarray:  # [tactics]
         """
         Return logits for all possible tactics.
 
@@ -95,7 +95,7 @@ class TF2Predict(Predict):
         tactic_logits, _, _ = self.pred_fn(model_input)  # [bs, tactics], _, _
         return tactic_logits[0].numpy()
 
-    def predict_arg_logits(self, state: tuple, tactic_id: int) -> np.ndarray:  # [args, cxt]
+    def predict_arg_logits(self, state: LoaderProofstate, tactic_id: int) -> np.ndarray:  # [args, cxt]
         """
         Return logits for all possible elements of local context and all argument positions.
 
@@ -116,7 +116,11 @@ class TF2Predict(Predict):
         local_context_arg_cnt = arg_cnt * cxt_len  # how many logits there are for local context elements in all arguments
         return tf.reshape(arg_logits.values[:local_context_arg_cnt], [arg_cnt, cxt_len])
 
-    def predict_tactic_arg_logits(self, state: tuple, tactic_expand_bound, allowed_model_tactics: list, available_global):
+    def predict_tactic_arg_logits(self,
+                                  state: LoaderProofstate,
+                                  tactic_expand_bound: int,
+                                  allowed_model_tactics: List[int],
+                                  available_global: Optional[List[int]]):
         """
         returns a matrix of tactic / arg logits expanding arguments call with top_tactics
         """
@@ -130,7 +134,7 @@ class TF2Predict(Predict):
         model_input = np_to_tensor(make_flat_batch_np(batch, len(self.dataset_consts.global_context),
                                                       self.dataset_consts.tactic_max_arg_num))
         _, arg_nums, arg_logits = self.pred_fn(model_input)
-        _, _, context = state
+        _, _, context, _ = state
         cxt_len = len(context)  # this is how many local context elements there are
         arg_cnt = sum(arg_nums)
         local_context_arg_cnt = arg_cnt * cxt_len  # how many logits there are for local context elements in all arguments
@@ -146,12 +150,12 @@ class TF2Predict(Predict):
 
     @predict_api_debugging
     def ranked_predictions(self,
-                           state: Tuple,
+                           state: LoaderProofstate,
                            allowed_model_tactics: List,
                            available_global: Optional[np.ndarray] = None,
                            tactic_expand_bound=20,
                            total_expand_bound=1000000):
-        _, _, context = state
+        _, _, context, _ = state
 
         context_len = len(context)
         global_context = np.arange(len(self.dataset_consts.global_context), dtype = np.uint32)

--- a/graph2tac/tfgnn/dataset.py
+++ b/graph2tac/tfgnn/dataset.py
@@ -6,7 +6,7 @@ import tensorflow as tf
 import tensorflow_gnn as tfgnn
 from pathlib import Path
 
-from graph2tac.loader.data_server import DataServer, GraphConstants, graph_as, LoaderGraph
+from graph2tac.loader.data_server import DataServer, GraphConstants, graph_as
 from graph2tac.tfgnn.graph_schema import proofstate_graph_spec, definition_graph_spec
 from graph2tac.common import logger
 
@@ -629,7 +629,10 @@ class DataServerDataset(Dataset):
         return tactic_id, local_arguments, global_arguments
 
     @classmethod
-    def _make_proofstate_graph_tensor(cls, state: Tuple, action: Tuple, graph_id: tf.Tensor) -> tfgnn.GraphTensor:
+    def _make_proofstate_graph_tensor(cls,
+                                      state: Tuple,
+                                      action: Tuple,
+                                      graph_id: tf.Tensor) -> tfgnn.GraphTensor:
         """
         Converts the data loader's proof-state representation into a TF-GNN compatible GraphTensor.
 
@@ -666,7 +669,7 @@ class DataServerDataset(Dataset):
 
     @classmethod
     def _make_definition_graph_tensor(cls,
-                                      loader_graph: LoaderGraph,
+                                      loader_graph: Tuple,
                                       num_definitions: tf.Tensor,
                                       definition_names: tf.Tensor
                                       ) -> tfgnn.GraphTensor:

--- a/graph2tac/tfgnn/graph_schema.py
+++ b/graph2tac/tfgnn/graph_schema.py
@@ -40,6 +40,15 @@ edge_sets {
 _proofstate_context_schema = """
 context {
   features {
+    key: "context_node_ids"
+    value: {
+      description: "[DATA] The ids of the nodes in the local context."
+      dtype: DT_INT64
+      shape { dim { size: -1 } }
+    }
+  }
+
+  features {
     key: "tactic"
     value: {
       description: "[LABEL] The id of the tactic we are trying to predict."
@@ -48,15 +57,6 @@ context {
   }
 
   features {
-    key: "context_node_ids"
-    value: {
-      description: "[DATA] The ids of the nodes in the local context."
-      dtype: DT_INT64
-      shape { dim { size: -1 } }
-    }
-  }
-  
-  features {
     key: "local_arguments"
     value: {
       description: "[LABEL] The local arguments we are trying to predict (or -1 for global/None)."
@@ -64,13 +64,37 @@ context {
       shape { dim { size: -1 } }
     }
   }
-  
+
   features {
     key: "global_arguments"
     value: {
       description: "[LABEL] The global arguments we are trying to predict (or -1 for local/None)."
       dtype: DT_INT64
       shape { dim { size: -1 } }
+    }
+  }
+
+  features {
+    key: "graph_id"
+    value: {
+      description: "[METADATA] The id of the graph, as returned by the loader."
+      dtype: DT_INT64
+    }
+  }
+
+  features {
+    key: "name"
+    value: {
+      description: "[METADATA] The name of the lemma this proofstate belongs to."
+      dtype: DT_STRING
+    }
+  }
+
+  features {
+    key: "step"
+    value: {
+      description: "[METADATA] The step number in the lemma proof."
+      dtype: DT_INT64
     }
   }
 }

--- a/graph2tac/tfgnn/graph_schema.py
+++ b/graph2tac/tfgnn/graph_schema.py
@@ -103,6 +103,15 @@ context {
 _definition_context_schema = """
 context {
   features {
+    key: "definition_names"
+    value: {
+      description: "[DATA] The names of the node labels being defined by this graph."
+      dtype: DT_STRING
+      shape { dim { size: -1 } }
+    }
+  }
+
+  features {
     key: "num_definitions"
     value: {
       description: "[LABEL] The number of node labels defined by this graph."


### PR DESCRIPTION
This PR exposes names for proof-states and definitions through the loader, which will be needed to write more advanced metrics or use definition names in the embedding calculations