### PR TITLE
Fidels/proofstate filtering

### DIFF
--- a/graph2tac/loader/data_server.py
+++ b/graph2tac/loader/data_server.py
@@ -1,7 +1,7 @@
 """
 data server provides the class to serve data to training
  - from a collection of bin files in a filesystem
- - from messages in a stream in interactive session (to be implmeneted)
+ - from messages in a stream in interactive session (to be implemented)
 """
 from typing import List, Tuple, Callable, NewType
 
@@ -24,7 +24,7 @@ import tqdm
 LoaderGraph = NewType('LoaderGraph', Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray])
 
 # loader_graph, root, context_node_ids, (proofstate_name, proofstate_step)
-LoaderProofstate = NewType('LoaderProofstate', Tuple[LoaderGraph, int, np.ndarray, Tuple[bytes, int]])
+LoaderProofstate = NewType('LoaderProofstate', Tuple[LoaderGraph, int, np.ndarray, Tuple[bytes, int, bool]])
 
 # loader_graph, num_definitions, definition_names
 LoaderDefinition = NewType('LoaderDefinition', Tuple[LoaderGraph, int, np.ndarray])
@@ -429,8 +429,9 @@ class Data2:
 
     # REFACTOR CLIENTS
     def step_state(self, data_point_idx: int) -> LoaderProofstate:
-        proof_step = self.get_proof_step(data_point_idx, skip_text=True)
-        return LoaderProofstate( (proof_step.graph, proof_step.root, proof_step.context, (proof_step.def_name, proof_step.step_in_proof)) )
+        proof_step = self.get_proof_step(data_point_idx, skip_text=False)
+        metadata = (proof_step.def_name, proof_step.step_in_proof, proof_step.action_text==proof_step.action_interm_text)
+        return LoaderProofstate( (proof_step.graph, proof_step.root, proof_step.context, metadata) )
 
     def step_state_text(self, data_point_idx: int):
         return self.get_proof_step(data_point_idx).state_text

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -438,7 +438,7 @@ def main_loop(reader, sock, predict: Predict, debug_dir, session_idx=0,
             online_graph = LoaderGraph( (train_node_labels, edges, edge_labels, edges_offset) )
 
             # FIDEL: is this information present? For now, just fill it in with dummy data
-            dummy_proofstate_info = ('dummy_proofstate_name', -1)
+            dummy_proofstate_info = ('dummy_proofstate_name', -1, True)
 
             logger.verbose(f"online_state: {online_graph}")
 

--- a/graph2tac/tfgnn/default_dataset_config.yml
+++ b/graph2tac/tfgnn/default_dataset_config.yml
@@ -1,3 +1,5 @@
 symmetrization: bidirectional
 add_self_edges: true
 max_subgraph_size: 1024
+exclude_none_arguments: false
+exclude_not_faithful: false

--- a/graph2tac/tfgnn/graph_schema.py
+++ b/graph2tac/tfgnn/graph_schema.py
@@ -97,6 +97,14 @@ context {
       dtype: DT_INT64
     }
   }
+  
+  features {
+    key: "faithful"
+    value: {
+      description: "[METADATA] 1 if the proofstate action is faithful (action_text == action_interm_text), 0 otherwise."
+      dtype: DT_INT64
+    }
+  }
 }
 """
 


### PR DESCRIPTION
This PR gives TFGNNPredict the ability to filter out certain tactic names from the predictions (e.g. to make sure we do not predict tactics that always require terms as arguments)