### PR TITLE
Fidels/label vectorization

### DIFF
--- a/graph2tac/tfgnn/graph_schema.py
+++ b/graph2tac/tfgnn/graph_schema.py
@@ -129,6 +129,27 @@ context {
 }
 """
 
+_vectorized_definition_context_schema = """
+context {
+  features {
+    key: "definition_name_vectors"
+    value: {
+      description: "[DATA] The tokenized names of the node labels being defined by this graph."
+      dtype: DT_INT64
+      shape { dim { size: -1 } dim { size: -1 } }
+    }
+  }
+
+  features {
+    key: "num_definitions"
+    value: {
+      description: "[LABEL] The number of node labels defined by this graph."
+      dtype: DT_INT64
+    }
+  }
+}
+"""
+
 _hidden_node_schema = """
 node_sets {
   key: "node"
@@ -188,6 +209,9 @@ proofstate_graph_spec = tfgnn.create_graph_spec_from_schema_pb(_proofstate_graph
 
 _definition_graph_schema = tfgnn.parse_schema(_bare_node_schema+_bare_edge_schema+_definition_context_schema)
 definition_graph_spec = tfgnn.create_graph_spec_from_schema_pb(_definition_graph_schema)
+
+_vectorized_definition_graph_schema = tfgnn.parse_schema(_bare_node_schema+_bare_edge_schema+_vectorized_definition_context_schema)
+vectorized_definition_graph_spec = tfgnn.create_graph_spec_from_schema_pb(_vectorized_definition_graph_schema)
 
 _hidden_graph_schema = tfgnn.parse_schema(_hidden_node_schema+_hidden_edge_schema+_hidden_context_schema)
 hidden_graph_spec = tfgnn.create_graph_spec_from_schema_pb(_hidden_graph_schema)

--- a/graph2tac/tfgnn/predict.py
+++ b/graph2tac/tfgnn/predict.py
@@ -150,8 +150,7 @@ class TFGNNPredict(Predict):
 
         dataset_yaml_filepath = log_dir / 'config' / 'dataset.yaml'
         with dataset_yaml_filepath.open('r') as yml_file:
-            dataset = Dataset(**yaml.load(yml_file, Loader=yaml.SafeLoader))
-        dataset._graph_constants = graph_constants
+            dataset = Dataset(graph_constants=graph_constants, **yaml.load(yml_file, Loader=yaml.SafeLoader))
         self._preprocess = dataset._preprocess
 
         # call to parent constructor to defines self._graph_constants


### PR DESCRIPTION
This PR fixes an annoying bug which makes it impossible to use RaggedTensors with string dtype in a MirroredStrategy, thus preventing multi-GPU training (the solution involves moving the tokenization for definition names to the input pipeline)