### PR TITLE
Ignore '@' characters from tactic text when filtering non-faithful's

### DIFF
--- a/graph2tac/loader/data_server.py
+++ b/graph2tac/loader/data_server.py
@@ -430,7 +430,8 @@ class Data2:
     # REFACTOR CLIENTS
     def step_state(self, data_point_idx: int) -> LoaderProofstate:
         proof_step = self.get_proof_step(data_point_idx, skip_text=False)
-        metadata = (proof_step.def_name, proof_step.step_in_proof, proof_step.action_text==proof_step.action_interm_text)
+        metadata = (proof_step.def_name, proof_step.step_in_proof,
+                    proof_step.action_text.replace('@', '')==proof_step.action_interm_text.replace('@', ''))
         return LoaderProofstate( (proof_step.graph, proof_step.root, proof_step.context, metadata) )
 
     def step_state_text(self, data_point_idx: int):


### PR DESCRIPTION
Tactics like `apply my_lemma` can be a bit tricky due to implicit
arguments (arguments that are assumed to be inferred by Coq's typesystem). When
`my_lemma` has, for example, two implicit arguments then `apply my_lemma` is
short-hand for `apply (@my_lemma _ _)` (where `_` are placeholders to be filled
in by Coq's type-inference, not by the model). In practice, this is functionally
exactly the same as `apply @my_lemma`. Hence, we should not filter out any
non-faitful tactics that only differ by use of '@'.

Analysis shows 952 instances of this, 194 unique. Probably not
super-significant, but still. Examples:

```
rewrite Ncring_initial.gen_phiZ_add --> rewrite @Ncring_initial.gen_phiZ_add
rewrite <- ring_mul_assoc --> rewrite <- @ring_mul_assoc
rewrite Raw.subset_spec --> rewrite @Raw.subset_spec
rewrite N2.recursion_succ --> rewrite @N2.recursion_succ
apply functional_extensionality_dep_good_refl --> apply @functional_extensionality_dep_good_refl
apply fold_add with (eqA := eq) --> apply fold_add with (eqA := @eq)
apply caseS with (v := v) --> apply @caseS with (v := v)
apply shiftout --> apply @shiftout
apply UniqInv with delta --> apply UniqInv with @delta
set (acc := nil) --> set (acc := @nil)
rewrite if_same --> rewrite @if_same
rewrite recursion_0 --> rewrite @recursion_0
apply remove_fold_1 with (eqA := Logic.eq) --> apply remove_fold_1 with (eqA := @Logic.eq)
apply fold_Equal with (eqA := M.Equal) --> apply fold_Equal with (eqA := @M.Equal)
```

Signed-off-by: Lasse Blaauwbroek <lasse@blaauwbroek.eu>