### PR TITLE
Patch predict server to work with dynamic global context

### DIFF
--- a/graph2tac/loader/hmodel.py
+++ b/graph2tac/loader/hmodel.py
@@ -34,7 +34,7 @@ def action_encode(action,
 
 def my_hash_of(state: LoaderProofstate, with_context: bool):
     graph, root, context, _ = state
-    what_to_hash = (*graph, context) if with_context else graph
+    what_to_hash = (*graph, context[0]) if with_context else graph
     state_hash = my_hash(''.join(hash_nparray(x) for x in what_to_hash).encode())
     return state_hash
 
@@ -132,7 +132,7 @@ class HPredict(Predict):
                            annotation: str = "",
                            debug: bool = False
                            ) -> Tuple[np.ndarray, List]:
-        graph, root, context, _ = state
+        graph, root, (context, dynamic_global_context), _ = state
         state_hash = my_hash_of(state, self._with_context)
         inverse_local_context = dict()
         for (i, node_idx) in enumerate(context):


### PR DESCRIPTION
This patch allows us to run benchmarks with the loader updated to provide the dynamic global context.
Had to make a new branch and re-commit the changes myself to avoid problems with sign-off comments, but this is Vasily's work.

Signed-off-by: Vasily Pestun <vasily.pestun@gmail.com>
Signed-off-by: Fidel I. Schaposnik Massolo <fidel.s@gmail.com>