### PR TITLE
Use datatypes for loader outputs

### DIFF
--- a/graph2tac/loader/hmodel.py
+++ b/graph2tac/loader/hmodel.py
@@ -7,7 +7,7 @@ import pickle
 import numpy as np
 from pathlib import Path
 
-from graph2tac.loader.data_server import DataServer, LoaderProofstate, LoaderDefinition
+from graph2tac.loader.data_server import DataServer, LoaderAction, LoaderProofstate, LoaderDefinition
 from graph2tac.predict import Predict, predict_api_debugging
 
 
@@ -22,14 +22,13 @@ def hash_nparray(array: np.array):
     return my_hash(x)
 
 
-def action_encode(action,
+def action_encode(action: LoaderAction,
                   local_context,
                   global_context):
-    tactic_idx, args = action
     context = (local_context, global_context)
-    res = [(arg[0], context[arg[0]][arg[1]]) for arg in args]
+    res = [(arg[0], context[arg[0]][arg[1]]) for arg in action.args]
 
-    return tactic_idx, res
+    return action.tactic_id, res
 
 
 def my_hash_of(state: LoaderProofstate, with_context: bool):

--- a/graph2tac/predict.py
+++ b/graph2tac/predict.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional, Callable, Dict
+from typing import List, Tuple, Optional, Callable, Dict, TypeVar
 
 import time
 import pickle
@@ -26,10 +26,11 @@ def cartesian_product(*arrays):
         arr[...,i] = a
     return arr.reshape(-1, la)
 
+RT = TypeVar('RT')  # return type
 
-def predict_api_debugging(api_call: Callable):
+def predict_api_debugging(api_call: Callable[..., RT]) -> Callable[..., RT]:
     api_name = api_call.__name__
-    def api_call_with_debug(self: "Predict", *args: List, **kwargs: Dict):
+    def api_call_with_debug(self: "Predict", *args: List, **kwargs: Dict) -> RT:
         if self._debug_dir is not None:
             debug_message_file = self._run_dir / f'{self._debug_message_number}.pickle'
             logger.debug(f'logging {api_name} call to {debug_message_file}')
@@ -81,7 +82,7 @@ class Predict:
             run_dirs = [int(run_dir.name) for run_dir in self._debug_dir.glob('*') if run_dir.is_dir()]
             run_number = max(run_dirs) + 1 if run_dirs else 1
 
-            self._run_dir = debug_dir / str(run_number)
+            self._run_dir = self._debug_dir / str(run_number)
             self._run_dir.mkdir()
             logger.info(f'running Predict in debug mode, messages will be stored at {self._run_dir}')
 

--- a/graph2tac/tf2/batches.py
+++ b/graph2tac/tf2/batches.py
@@ -4,14 +4,17 @@ It takes a stream of datapoints and output a stream of batches
 """
 
 import random
+from typing import Generic, Iterable, TypeVar
 
-class Batches:
+T = TypeVar('T')
+
+class Batches(Generic[T]):
     """
     constructs iterator of batches from stream iterator of datapoints
     and batch size. Never returns empty batch but stops iterations
     when input is depleted
     """
-    def __init__(self, stream: iter, batch_size: int):
+    def __init__(self, stream: Iterable[T], batch_size: int):
         self.__stream = iter(stream)
         self.__batch_size = batch_size
         if hasattr(stream, '__len__'):
@@ -24,7 +27,7 @@ class Batches:
     def __iter__(self):
         return self
 
-    def __next_batch(self):
+    def __next_batch(self) -> list[T]:
         batch = []
         while len(batch) < self.__batch_size:
             try:
@@ -33,7 +36,7 @@ class Batches:
                 break
         return batch
 
-    def __next__(self):
+    def __next__(self) -> list[T]:
         batch = self.__next_batch()
         if len(batch) == 0:
             raise StopIteration
@@ -42,7 +45,8 @@ class Batches:
     def __len__(self):
         return (self.__size)
 
-def Repeat(data, shuffled=False):
+
+def Repeat(data: Iterable[T], shuffled=False) -> Iterable[T]:
     """
     repeates infinitely the original iterator, reshuffling before each pass   
     """

--- a/graph2tac/tf2/train.py
+++ b/graph2tac/tf2/train.py
@@ -199,29 +199,9 @@ class Checkpointer:
         param_yaml_path = subdir / "optim_params.yaml"
         param_yaml_path.write_text(self.optimizer_params.to_yaml())
 
-    def test_load_from_checkpoint(self, epoch: int):
-        # TODO(jrute): Remove when done testing this
-        subdir = self.checkpoint_dir / f"{self.model_name}__epoch{epoch}"
-        new_model_wrapper = ModelWrapper(checkpoint=subdir)
     def load_from_checkpoint(self, epoch: int):
         subdir = self.checkpoint_dir / f"{self.model_name}__epoch{epoch}"
         self.model_wrapper = ModelWrapper(checkpoint=subdir)
-
-    def test_predict(self, epoch: int, batch):
-        # TODO(jrute): Remove when done testing this
-        subdir = self.checkpoint_dir / f"{self.model_name}__epoch{epoch}"
-        predictor = Predict(checkpoint_dir=subdir)
-        state = batch[0][0]
-        cxt = state[3]
-        tactic = batch[0][1][0]
-        arg_mask = batch[0][1][2]
-        arg_cnt = arg_mask.sum()
-        print("tac_result", predictor.predict_tactic_logits(state).shape)
-        r = predictor.predict_arg_logits(state, tactic)
-        print("arg_result", r.shape)
-        print("arg_mask", arg_mask)
-        print("expected_arg_size:", (arg_cnt, len(cxt)))
-        assert r.shape == (arg_cnt, len(cxt))
 
 
 class FingerPrinter():

--- a/graph2tac/tfgnn/dataset.py
+++ b/graph2tac/tfgnn/dataset.py
@@ -779,7 +779,7 @@ class DataServerDataset(Dataset):
         """
         # get the proofstates from the DataServer
         proofstates = tf.data.Dataset.from_generator(
-            map(self._loader_to_proofstate_data, lambda: self.data_server.data_train(shuffled=False, as_text=False)),
+            lambda: map(self._loader_to_proofstate_data, self.data_server.data_train(shuffled=False, as_text=False)),
             output_signature=self.proofstate_data_spec
         )
         return proofstates.map(self._make_proofstate_graph_tensor, num_parallel_calls=tf.data.AUTOTUNE)
@@ -799,7 +799,7 @@ class DataServerDataset(Dataset):
         @return: a tf.data.Dataset streaming GraphTensor objects
         """
         dataset = tf.data.Dataset.from_generator(
-            map(self._loader_to_definition_data, lambda: self.data_server.def_cluster_subgraphs()),
+            lambda: map(self._loader_to_definition_data, self.data_server.def_cluster_subgraphs()),
             output_signature=self.definition_data_spec
         )
         return dataset.map(self._make_definition_graph_tensor, num_parallel_calls=tf.data.AUTOTUNE)


### PR DESCRIPTION
Now the dataloader returns proper dataclasses including `LoaderProofstate`, `LoaderAction` and `LoaderDefinition`.  This provides a uniform and easy to use interface which will hopefully reduce bugs.  I refactored all the code to use these.  Here is how they are used in practice:
* They are converted into TF (and other as follows)
  * TF2: Converts them into FlatbatchNP and FlatbatchDefNP for loading into tensorflow for training and prediction
  * TFGNN: Converts them into tuples for loading into a tensorflow dataset for training and prediction.  (The converting them back to a tuple isn't ideal, but I didn't want to bother with TF dataclasses which can require a lot of boilerplate code.  Also, they only stay a tuple for one step, before getting converted by `_make_definition_graph_tensor` to tf-gnn objects.)  Separately, the evaluation code also passes around the state and action objects seperately)
  * hmodel: Gets the information it needs from these loader classes to "train" a model or compute a prediction
* The loader objects are created in two settings
  * In the loader where they are sent by iterators for training in the 3 models
  * In the prediction server where they are created from the information being sent from Coq.

This change adds little code and in many places removes code.  Most of the added code is in doc strings (which I of course didn't need to add but thought this would be helpful since this is some of the most confusing datatypes we have in the code.)

I still need to do the following:
- [x] Test training a tf2 model 
- [x] Test training a tf-gnn model 
- [x] Test training a hmodel model 
- [x] Test server with tf2 model making sure it still can prove trivial theorems on first prediction using existing model
- [x] Test server with tf-gnn model making sure it still can prove trivial theorems on first prediction using existing model
- [x] Test server with hmodel making sure it still can prove trivial theorems on first prediction using existing model
- [ ] Modify the `tfgnn.ipynb` notebook accordingly.