### PR TITLE
Load datasets faster and without bugs

### DIFF
--- a/graph2tac/tfgnn/dataset.py
+++ b/graph2tac/tfgnn/dataset.py
@@ -106,6 +106,7 @@ class Dataset:
 
         # apply the symmetrization and self-edge transformations
         proofstate_dataset = proofstate_dataset.apply(self._preprocess)
+        proofstate_dataset = proofstate_dataset.cache()
 
         # create dataset of split labels
         split_logits = tf.math.log(tf.constant(split, dtype=tf.float32) / sum(split))
@@ -119,13 +120,16 @@ class Dataset:
 
         # get train dataset (shuffling if necessary)
         train = pair_dataset.filter(lambda _, label: label == 0).map(lambda proofstate_graph, _: proofstate_graph)
+        train = train.cache()
+
         if shuffle:
             train = train.shuffle(buffer_size=self.SHUFFLE_BUFFER_SIZE)
 
         # get validation dataset
         valid = pair_dataset.filter(lambda _, label: label == 1).map(lambda proofstate_graph, _: proofstate_graph)
+        valid = valid.cache()
 
-        return train.cache(), valid.cache()
+        return train, valid
 
     def definitions(self, shuffle: bool = False) -> tf.data.Dataset:
         """
@@ -135,9 +139,10 @@ class Dataset:
         @return: a dataset with all the definition clusters
         """
         definitions = self._definitions().apply(self._preprocess)
+        definitions = definitions.cache()
         if shuffle:
             definitions = definitions.shuffle(buffer_size=self.SHUFFLE_BUFFER_SIZE)
-        return definitions.cache()
+        return definitions
 
     def tokenize_definition_graph(self, definition_graph: tfgnn.GraphTensor) -> tfgnn.GraphTensor:
         """

--- a/graph2tac/tfgnn/train.py
+++ b/graph2tac/tfgnn/train.py
@@ -227,13 +227,13 @@ class Trainer:
 
         return (proofstate_graph, definition_graph), outputs
 
-    def _prepare_dataset(self, dataset: tf.data.Dataset) -> tf.data.Dataset:
+    def _prepare_dataset(self, dataset: tf.data.Dataset, definitions: Optional[tf.data.Dataset]) -> tf.data.Dataset:
         # create input-output pairs
         dataset = dataset.map(self.prediction_task.create_input_output)
 
         # add definitions if necessary
-        if self.definition_task is not None:
-            definitions = self.dataset.definitions(shuffle=False).map(self.dataset.tokenize_definition_graph)
+        if definitions is not None:
+            definitions = definitions.map(self.dataset.tokenize_definition_graph)
             definitions = definitions.repeat().shuffle(self.dataset.SHUFFLE_BUFFER_SIZE)
             dataset = tf.data.Dataset.zip(datasets=(dataset, definitions))
             dataset = dataset.map(self._input_output_mixing)
@@ -310,8 +310,21 @@ class Trainer:
         train_proofstates, valid_proofstates = self.dataset.proofstates(split=split,
                                                                         split_random_seed=split_random_seed,
                                                                         shuffle=True)
-        train_proofstates = train_proofstates.apply(self._prepare_dataset).batch(batch_size).prefetch(tf.data.AUTOTUNE)
-        valid_proofstates = valid_proofstates.apply(self._prepare_dataset).batch(batch_size).prefetch(tf.data.AUTOTUNE)
+        if self.definition_task:
+            definitions = self.dataset.definitions(shuffle=False)
+        else:
+            definitions = None
+
+        train_proofstates = (train_proofstates
+            .apply(lambda dataset: self._prepare_dataset(dataset, definitions))
+            .batch(batch_size)
+            .prefetch(tf.data.AUTOTUNE)
+        )
+        valid_proofstates = (valid_proofstates
+            .apply(lambda dataset: self._prepare_dataset(dataset, definitions))
+            .batch(batch_size)
+            .prefetch(tf.data.AUTOTUNE)
+        )
 
         # prepare callbacks
         callbacks = self._callbacks()

--- a/graph2tac/tfgnn/train.py
+++ b/graph2tac/tfgnn/train.py
@@ -325,8 +325,7 @@ class Trainer:
 
             # logs for this run
             tensorboard_callback.log_run(trainer_config=self.get_config(),
-                                         dataset_stats=self.dataset.stats(split=split,
-                                                                          split_random_seed=split_random_seed),
+                                         dataset_stats={},
                                          run_config={
                                              'total_epochs': total_epochs,
                                              'batch-size': batch_size,


### PR DESCRIPTION
This PR fixes the issues with loading the datasets where we were caching at the wrong places.  Now the datasets should be shuffled between epochs and loading validation and training together will only require one pass through the dataset.  I've also turned off computing statistics since it was so time consuming and had its own inefficiencies.