### PR TITLE
Fix bug in def name embedding

### DIFF
--- a/graph2tac/tfgnn/models.py
+++ b/graph2tac/tfgnn/models.py
@@ -960,7 +960,6 @@ class DenseDefinitionHead(tf.keras.layers.Layer):
                     input_dim=Dataset.MAX_LABEL_TOKENS,
                     output_dim=hidden_size,
                 ),
-                tf.keras.layers.Lambda(lambda x: x.to_tensor()), # align ragged tensor
                 self._name_layer_core,
             ])
 


### PR DESCRIPTION
Each definition name is a different length.  There was a line in the code which I'm deleting in this PR, which padded the name to be the same size as the longest name in the batch.  There was no masking on the padding (and it happened after the token embeddings, so it padded the input to the RNN model with zero vectors).

Every batch computed the name slightly differently based on the padding, and the embeddings at inference time (which were not padded since the batches have size one) came out differently than at training time (where for most names there was at least some padding).  This PR removes any such padding since RNN models in TF don't need to be padded like this.