### PR TITLE
Fix bug in predict embeddings

### DIFF
--- a/graph2tac/tfgnn/models.py
+++ b/graph2tac/tfgnn/models.py
@@ -322,6 +322,18 @@ class GraphEmbedding(tfgnn.keras.layers.MapFeatures):
         })
         return config
 
+    def copy(self) -> "GraphEmbedding":
+        new_graph_embs_layer = GraphEmbedding(
+            node_label_num=self._node_label_num,
+            edge_label_num=self._edge_label_num,
+            hidden_size=self._hidden_size,
+            unit_normalize=self._unit_normalize,
+            name=self.name 
+        )
+        new_graph_embs_layer._node_embedding = self._node_embedding
+        new_graph_embs_layer._edge_embedding = self._edge_embedding
+        return new_graph_embs_layer
+
     def lookup_node_embedding(self, indices):
         """Lookup node embeddings directly"""
         return self._node_embedding(indices)
@@ -333,7 +345,7 @@ class GraphEmbedding(tfgnn.keras.layers.MapFeatures):
     def set_node_embeddings(self, embeddings):
         return self._node_embedding.set_weights([embeddings])
 
-    def extend_embeddings(self, new_node_label_num: int):
+    def _extend_embeddings(self, new_node_label_num: int):
         """Extend the embedding layer in place"""
         new_node_embedding = self._node_emb_layer(
             node_label_num=new_node_label_num,
@@ -347,6 +359,12 @@ class GraphEmbedding(tfgnn.keras.layers.MapFeatures):
         self._node_embedding = new_node_embedding
         self._node_label_num = new_node_label_num
         self.set_node_embeddings(new_embeddings)
+    
+    def extend_embeddings(self, new_node_label_num: int) -> "GraphEmbedding":
+        """Return a new layer with extended embeddings"""
+        new_layer = self.copy()
+        new_layer._extend_embeddings(new_node_label_num)
+        return new_layer
         
     def update_node_embeddings(self, embeddings, indices):
         emb_vars = self._node_embedding.embeddings

--- a/graph2tac/tfgnn/predict.py
+++ b/graph2tac/tfgnn/predict.py
@@ -281,9 +281,11 @@ class TFGNNPredict(Predict):
             new_node_label_num = max(global_context)+1
             if new_node_label_num > self._graph_constants.node_label_num:
                 logger.info(f'extending global context from {self._graph_constants.node_label_num} to {new_node_label_num} elements')
-                self.prediction_task.graph_embedding.extend_embeddings(new_node_label_num)
+                new_graph_emb_layer = self.prediction_task.graph_embedding.extend_embeddings(new_node_label_num)
+                self.prediction_task.graph_embedding = new_graph_emb_layer
+                
                 if self.definition_task is not None:
-                    self.definition_task._graph_embedding = self.prediction_task.graph_embedding
+                    self.definition_task._graph_embedding = new_graph_emb_layer
                 self._graph_constants.node_label_num = new_node_label_num
 
             # update the global arguments logits head (always necessary, because the global context may shrink!)


### PR DESCRIPTION
I made a mistake when refactoring the embeddings.  I tested it but not well enough.  (I tested that the embedding table was being extended properly, but apparently it wasn't being rebuilt since I extended it in-place instead of making a new layer.)  This fixes it.  I've now tested that an entire benchmark works.