### PR TITLE
Fix bugs in predict server

### DIFF
--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -31,8 +31,9 @@ def apply_temperature(confidences: ArrayLike, temperature: float) -> NDArray[np.
     assuming the truncated tail of the probability distribution
     is clustered in one unseen element
     """
-    res = np.array(confidences, np.float64)**(1/temperature)
-    res /= res.sum() + (1-sum(confidences))**(1/temperature)
+    confidences = np.array(confidences, np.float64)
+    res = confidences**(1/temperature)
+    res /= res.sum() + (1-confidences.sum())**(1/temperature)
     return res
 
 @dataclass

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -330,12 +330,12 @@ class PredictServer(AbstractDataServer):
             if tactic.ident not in self._tactic_to_i
         ]
         unaligned_definitions = [
-            d for d in msg.definitions.definitions
+            (d.node.nodeid, d) for d in msg.definitions.definitions
             if d.name not in self._def_name_to_i
         ]
 
         unaligned_tactics = sorted(unaligned_tactics)
-        unaligned_definitions = sorted(unaligned_definitions)
+        unaligned_definitions = [d for _, d in sorted(unaligned_definitions)]
         return CheckAlignmentResponse(
             unknown_tactics = unaligned_tactics,
             unknown_definitions = unaligned_definitions,

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -330,7 +330,7 @@ class PredictServer(AbstractDataServer):
             if tactic.ident not in self._tactic_to_i
         ]
         unaligned_definitions = [
-            d.node.nodeid for d in msg.definitions.definitions
+            d for d in msg.definitions.definitions
             if d.name not in self._def_name_to_i
         ]
 

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -243,7 +243,7 @@ class PredictServer(AbstractDataServer):
                     )   
                 for n in new_defined_nodes:
                     assert n >= prev_defined_nodes and n not in defined_nodes, (
-                        f"Something is wrong with the definition clusters."
+                        f"Something is wrong with the definition clusters. "
                         f"Attempting to compute definition embedding for node labels {new_defined_nodes} "
                         f"({cluster_state.definition_names}) "
                         f"for which node label {n} has already been computed."

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -337,8 +337,8 @@ class PredictServer(AbstractDataServer):
         unaligned_tactics = sorted(unaligned_tactics)
         unaligned_definitions = sorted(unaligned_definitions)
         return CheckAlignmentResponse(
-            unalignedTactics = unaligned_tactics,
-            unalignedDefinitions = unaligned_definitions,
+            unknown_tactics = unaligned_tactics,
+            unknown_definitions = unaligned_definitions,
         )
 
 def prediction_loop(predict_server: PredictServer, capnp_socket: socket.socket, record_file: Optional[BinaryIO]):

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -343,14 +343,16 @@ class PredictServer(AbstractDataServer):
 
 def prediction_loop(predict_server: PredictServer, capnp_socket: socket.socket, record_file: Optional[IO]):
     
-    if predict_server.config.with_meter:
-        capnp_socket = tqdm.tqdm(capnp_socket)
     message_generator = capnp_message_generator(capnp_socket, record_file)
+    if predict_server.config.with_meter:
+        message_generator_iterator = tqdm.tqdm(message_generator)
+    else:
+        message_generator_iterator = message_generator
     log_cnts = predict_server.log_cnts
     log_cnts.session_idx += 1
     log_cnts.thm_idx = -1
 
-    for msg in message_generator:
+    for msg in message_generator_iterator:
         if isinstance(msg, CheckAlignmentMessage):
             logger.info("checkAlignment request")
             response = predict_server.check_alignment(msg)

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -242,6 +242,12 @@ class PredictServer(AbstractDataServer):
                         f"the definition embedding for node label {n} used in that definition."
                     )   
                 for n in new_defined_nodes:
+                    assert n >= prev_defined_nodes and n not in defined_nodes, (
+                        f"Something is wrong with the definition clusters."
+                        f"Attempting to compute definition embedding for node labels {new_defined_nodes} "
+                        f"({cluster_state.definition_names}) "
+                        f"for which node label {n} has already been computed."
+                    )
                     defined_nodes.add(n)
 
                 self.model.compute_new_definitions([cluster_state])

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -330,12 +330,10 @@ class PredictServer(AbstractDataServer):
             if tactic.ident not in self._tactic_to_i
         ]
         unaligned_definitions = [
-            (d.node.nodeid, d) for d in msg.definitions.definitions
+            d for d in msg.definitions.definitions
             if d.name not in self._def_name_to_i
         ]
 
-        unaligned_tactics = sorted(unaligned_tactics)
-        unaligned_definitions = [d for _, d in sorted(unaligned_definitions)]
         return CheckAlignmentResponse(
             unknown_tactics = unaligned_tactics,
             unknown_definitions = unaligned_definitions,

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -345,14 +345,14 @@ def prediction_loop(predict_server: PredictServer, capnp_socket: socket.socket, 
     
     message_generator = capnp_message_generator(capnp_socket, record_file)
     if predict_server.config.with_meter:
-        message_generator_iterator = tqdm.tqdm(message_generator)
+        message_iterator = tqdm.tqdm(message_generator)
     else:
-        message_generator_iterator = message_generator
+        message_iterator = message_generator
     log_cnts = predict_server.log_cnts
     log_cnts.session_idx += 1
     log_cnts.thm_idx = -1
 
-    for msg in message_generator_iterator:
+    for msg in message_iterator:
         if isinstance(msg, CheckAlignmentMessage):
             logger.info("checkAlignment request")
             response = predict_server.check_alignment(msg)


### PR DESCRIPTION
* Fix bug where definitions are updated in the reverse order.
* Added an online check that the order is correct since otherwise it would fail silently.
* Added better type annotations.  (I may have went overboard, but it did help me understand the code and catch some bugs.)
* Fixed a number of small bugs my editor found.  Mostly these were in unusual paths through the code that are not traveled during typical running of the server, but for which the code would likely crash if it went down this path.