### PR TITLE
Mirek/reindex

### DIFF
--- a/graph2tac/loader/data_classes.py
+++ b/graph2tac/loader/data_classes.py
@@ -56,13 +56,7 @@ LoaderAction, LoaderActionSpec = namedtuple_with_spec(
     # If `global_args[i] == g` for `g >= 0`, then the `i`th arg is a global definition with index `g`.
     # Otherwise, the values are set to '-1'
     
-    # The local argument is an index into `context.local_context` for the corresponding proofstate,
-    # but the global argument is the index into the list of global definitions returned by the dataserver and kept
-    # in the model.  In particular, the global argument is neither an index into `context.global_context`
-    # for the proofstate nor the node label of a definition (which would instead be offset by the number of base node labels).
-
-    # Hence the smallest possible global argument index is 0 and it can be larger than
-    # `len(context.global_context)` for the corresponding proofstate.
+    # The local and global arguments are indices into `context.local_context` and `context.global_context` respectively.
 )
 
 LoaderDefinition, LoaderDefinitionSpec = namedtuple_with_spec(

--- a/graph2tac/loader/data_server.py
+++ b/graph2tac/loader/data_server.py
@@ -626,7 +626,9 @@ class DataServer(AbstractDataServer):
             if arg_local < 0: arg_global = self._def_node_to_i.get(arg, -1)
             else: arg_global = -1
             # node reindexing: "node label" -> "index to global_context"
-            if arg_global >= 0: arg_global -= self._base_node_label_num
+            if arg_global >= 0:
+                arg_global -= self._base_node_label_num
+                [arg_global] = np.flatnonzero(available_global_context == arg_global)
             if arg_global < 0 and arg_local < 0: has_none_argument = True
             local_args.append(arg_local)
             global_args.append(arg_global)

--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -947,11 +947,17 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
 
         global_args = graph_tensor.context['global_arguments']
         available_global_context = graph_tensor.context['global_context_ids']
-        global_args = tf.where(
-            global_args >= 0,
-            tf.gather(available_global_context, tf.maximum(global_args, 0), batch_dims=1),
-            tf.constant(-1, dtype = tf.int64),
-        )
+        if tf.size(available_global_context) > 0:
+            global_args = tf.where(
+                global_args >= 0,
+                tf.gather(available_global_context, tf.maximum(global_args, 0), batch_dims=1),
+                tf.constant(-1, dtype = tf.int64),
+            )
+            tf.print("SHAPE AFTER:", tf.shape(global_args), global_args.dtype, global_args.row_lengths())
+        else:
+            # if the available_global_context is empty, then global_args contains no references to the global context
+            # hence we can leave it the same
+            global_args = global_args
 
         outputs = {GlobalArgumentPrediction.TACTIC_LOGITS: graph_tensor.context['tactic'],
                    GlobalArgumentPrediction.LOCAL_ARGUMENTS_LOGITS: graph_tensor.context['local_arguments'],

--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -944,9 +944,18 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
     @staticmethod
     def create_input_output(graph_tensor: tfgnn.GraphTensor) -> Tuple[
         tfgnn.GraphTensor, Dict[str, Union[tf.Tensor, tf.RaggedTensor]]]:
+
+        global_args = graph_tensor.context['global_arguments']
+        available_global_context = graph_tensor.context['global_context_ids']
+        global_args = tf.where(
+            global_args >= 0,
+            tf.gather(available_global_context, tf.maximum(global_args, 0), batch_dims=1),
+            tf.constant(-1, dtype = tf.int64),
+        )
+
         outputs = {GlobalArgumentPrediction.TACTIC_LOGITS: graph_tensor.context['tactic'],
                    GlobalArgumentPrediction.LOCAL_ARGUMENTS_LOGITS: graph_tensor.context['local_arguments'],
-                   GlobalArgumentPrediction.GLOBAL_ARGUMENTS_LOGITS: graph_tensor.context['global_arguments']}
+                   GlobalArgumentPrediction.GLOBAL_ARGUMENTS_LOGITS: global_args}
         return graph_tensor, outputs
 
     def loss(self) -> Dict[str, tf.keras.losses.Loss]:


### PR DESCRIPTION
Make the global argument and index into the global context instead of an absolute index.  This will make our model more scalable in the end.

This quickly gets turned back to what it was before, but we will push it further back into the neural network.