### PR TITLE
Avoid dependence on valid_indices

### DIFF
--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -638,9 +638,6 @@ class LocalArgumentPrediction(TacticPrediction):
         num_arguments = tf.shape(logits)[1]
         num_logits = tf.shape(logits)[2]
         return tf.reshape(logits, shape=(tactic_expand_bound, -1, num_arguments, num_logits))
-        #x = tf.shape(tf.reshape(logits, shape=(tactic_expand_bound, -1, num_arguments, num_logits)))
-        #x = tf.keras.backend.print_tensor(x, message="Logits")
-        #return x
 
     @classmethod
     def _reshape_global_inference_logits(cls, logits: tf.Tensor, tactic_expand_bound: int, dyn_global_context: tf.RaggedTensor) -> tf.Tensor:


### PR DESCRIPTION
This simple hack makes it so that the inference model returns logits according to the dynamic global context.  It makes the following assumptions (which at least are currently true):
* the dynamic global context are indices into the valid_indices
* the batch size to the inference model is 1 (or at least the dynamic global indices are the same size for all elements of the batch)

To make sure this works, I made another branch [`jrute/avoid-dependence-on-valid-indices-with-tests](https://github.com/IBM/graph2tac/tree/jrute/avoid-dependence-on-valid-indices-with-tests) where I did two things:
* Merged in the predict server tests and made sure they passed
* Made an [experimental commit](https://github.com/IBM/graph2tac/commit/10ed4d18f9f76ad5fd424d1a10a20df5a0ba78dc) where I messed with both the valid_indices and the dynamic global context and made sure it still passed the tests as intended.