### PR TITLE
Use ragged tensors for training model

### DIFF
--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -315,7 +315,7 @@ class GlobalArgumentModel(tf.keras.Model):
         # local arguments
         local_arguments = y[GlobalArgumentPrediction.LOCAL_ARGUMENTS_LOGITS]  # [batch, None(args)]
         local_arguments_logits = y_pred[GlobalArgumentPrediction.LOCAL_ARGUMENTS_LOGITS]  # [batch, None(args), None(context]
-        local_arguments_logits = local_arguments_logits.to_tensor(default_value=-np.inf, shape=[None, None, 5000])  # [batch, max(args), context] # FIXME(jrute) 
+        local_arguments_logits = local_arguments_logits.to_tensor(default_value=-np.inf)  # [batch, max(args), context] # FIXME(jrute) 
         local_true = tf.squeeze(local_arguments, 1)  # [batch, None(args)]
         local_logits = ragged_logits(local_arguments, local_arguments_logits)  # [batch, None(args), context]
         local_best_logit = tf.ragged.map_flat_values(tf.reduce_max, local_logits, axis=-1)  # [batch, None(args)]
@@ -325,7 +325,7 @@ class GlobalArgumentModel(tf.keras.Model):
         # global arguments
         global_arguments = y[GlobalArgumentPrediction.GLOBAL_ARGUMENTS_LOGITS]  # [batch, None(args)]
         global_arguments_logits = y_pred[GlobalArgumentPrediction.GLOBAL_ARGUMENTS_LOGITS]  # [batch, None(args), None(context]
-        global_arguments_logits = global_arguments_logits.to_tensor(default_value=-np.inf, shape=[None, None, 5000])  # [batch, max(args), context] # FIXME(jrute) 
+        global_arguments_logits = global_arguments_logits.to_tensor(default_value=-np.inf)  # [batch, max(args), context] # FIXME(jrute) 
         global_true = tf.squeeze(global_arguments, 1)  # [batch, None(args)]
         global_logits = ragged_logits(global_arguments, global_arguments_logits)
         global_best_logit = tf.ragged.map_flat_values(tf.reduce_max, global_logits, axis=-1)  # [batch, None(args)]


### PR DESCRIPTION
This PR is one initial step into speeding up and improving memory efficiency in the model.  The major changes are as follows:
* The training model now outputs a tensor of shape `[batch_size, None(num_args), None(context)]`.  In other words the arguments and context dimension are now ragged where the arguments dimension only ranges over argument positions used for that tactic, and the context dimension only ranged over elements in the local context or dynamic global context.
* The ground truth global arguments given to the model are indexed into the dynamic global context now.  This matches the way they are outputted by the training model.
* The losses and metrics are changed accordingly.  There are still some inefficiencies (especially in the accuracy calculations) where I convert a ragged tensor of logits back into a non-ragged tensor.  That can be fixed a bit later, but I want to start working on the main bottleneck, which is the linear operation.

This PR is a first step to speeding up the model.  Now that we have a foothold with the ragged tensor, future PRs can address the following:
- [ ] Making the linear operation (matrix multiplication) which creates the logits more efficient (but only performing the calculation over the dynamic global context and the valid argument positions)
- [ ] Consolidating the code for the local and global arguments since they are now using the same idea
- [ ] Remove any dependencies on `_valid_indices` which is no longer needed.
- [ ] Clean up the accuracy calculations to not convert back to non-ragged tensors first.
- [ ] Clean up the prediction calculation to not convert back to non-ragged tensors first.