### PR TITLE
Remove valid_indices

### DIFF
--- a/graph2tac/tfgnn/predict.py
+++ b/graph2tac/tfgnn/predict.py
@@ -237,8 +237,7 @@ class TFGNNPredict(Predict):
 
             # update the global arguments logits head (always necessary, because the global context may shrink!)
             self.prediction_task.global_arguments_logits.update_embedding_matrix(
-                embedding_matrix=self.prediction_task.graph_embedding.get_node_embeddings(),
-                valid_indices=tf.constant(self.graph_constants.global_context, dtype=tf.int32)
+                embedding_matrix=self.prediction_task.graph_embedding.get_node_embeddings()
             )
 
             # clear the inference model cache to force re-creation of the inference models using the new layers

--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -511,7 +511,6 @@ class TacticPrediction(PredictionTask):
         # a layer to compute tactic logits from tactic embeddings
         self.tactic_logits_from_embeddings = LogitsFromEmbeddings(
             embedding_matrix=self.tactic_embedding.embeddings,
-            valid_indices=tf.range(self._graph_constants.tactic_num),
             cosine_similarity=False,
             name=self.TACTIC_LOGITS
         )
@@ -856,7 +855,6 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
         # create a layer to extract logits from the node label embeddings
         self.global_arguments_logits = LogitsFromEmbeddings(
             embedding_matrix=self.graph_embedding.get_node_embeddings(),
-            valid_indices=tf.constant(self._graph_constants.global_context, dtype=tf.int32),
             cosine_similarity=self._global_cosine_similarity
         )
 


### PR DESCRIPTION
This simple PR removes the need for valid_indices, which was already superfluous since it was always equal to `range(n)` where `n` was the length of the embedding tensor, and hence `tf.gather(emb_matrix, self._valid_indices)` was a no-op.

The tests all pass.