### PR TITLE
Speed up model by switching to ragged tensors

### DIFF
--- a/graph2tac/tfgnn/models.py
+++ b/graph2tac/tfgnn/models.py
@@ -79,6 +79,9 @@ class LogitsFromEmbeddings(tf.keras.layers.Layer):
     def update_embedding_matrix(self, embedding_matrix: tf.Variable):
         self._embedding_matrix = embedding_matrix
 
+    def get_keys_embeddings(self):
+        return self._embedding_matrix
+
     def call(self, hidden_state, training=False):
         emb_matrix = self._embedding_matrix
 

--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -64,6 +64,18 @@ def ragged_logits(y_true: tf.RaggedTensor, y_pred: tf.Tensor) -> Tuple[tf.Ragged
         logits = tf.RaggedTensor.from_tensor(y_pred, lengths=y_true.row_lengths())
     return logits
 
+def convert_ragged_logits_to_dense(logits: tf.RaggedTensor) -> tf.Tensor:
+    # logits shape: [batch, None(args), None(context)]
+
+    # expand context (replacing unused context element logits with -inf)
+    # shape: [batch, None(args), max(context)]
+    logits = logits.with_values(logits.values.to_tensor(default_value=-np.inf))
+
+    # expand args (replacing unused arg position logits with 0.0)
+    # shape: [batch, max(args), max(context)]
+    logits = logits.to_tensor(default_value=0.0)
+
+    return logits
 
 @tf.function
 def _local_arguments_pred(y_true: tf.Tensor, y_pred: tf.Tensor) -> tf.Tensor:
@@ -615,6 +627,32 @@ class TacticPrediction(PredictionTask):
         return {TacticPrediction.TACTIC_LOGITS: [tf.keras.metrics.SparseCategoricalAccuracy(name="accuracy")]}
 
 
+class QueryKeyMul(tf.keras.layers.Layer):
+    def __init__(
+        self,
+        name="query_key_mul",
+        **kwargs
+    ):
+        super().__init__(name=name, **kwargs)
+
+    def call(
+        self, 
+        queries: tf.RaggedTensor, # [batch, None(args), hdim]
+        keys: tf.RaggedTensor, # [batch, None(context), hdim]
+        training=False
+    ) -> tf.RaggedTensor: # [batch, None(args), None(context)]
+        @tf.function
+        def linear_op(qk):
+            x = tf.einsum("ij, kj -> ik", qk[0], qk[1])
+            x = tf.RaggedTensor.from_tensor(x)
+            return x
+        return tf.map_fn(
+            linear_op,
+            elems=[queries, keys],
+            fn_output_signature=tf.RaggedTensorSpec(shape=[None, None])
+        )
+
+
 class LocalArgumentPrediction(TacticPrediction):
     """
     Wrapper for the base tactic plus local argument prediction tasks.
@@ -668,10 +706,10 @@ class LocalArgumentPrediction(TacticPrediction):
         return config
 
     @staticmethod
-    def _local_arguments_logits(scalar_proofstate_graph: tfgnn.GraphTensor,
-                                hidden_graph: tfgnn.GraphTensor,
-                                hidden_state_sequences: tf.Tensor
-                                ) -> tf.Tensor:
+    def _local_context_hidden(
+        scalar_proofstate_graph: tfgnn.GraphTensor,
+        hidden_graph: tfgnn.GraphTensor,
+    ) -> tf.RaggedTensor:  # [batch_size, None(local_context), hidden_size]
         """
         Computes logits for local arguments from the hidden states and the local context node ids.
         """
@@ -689,23 +727,8 @@ class LocalArgumentPrediction(TacticPrediction):
 
         # the hidden states for the nodes in the local context
         # [ batch_size, None(num_context_nodes), hidden_size ]
-        context_node_hidden_states = tf.gather(hidden_graph.node_sets['node']['hidden_state'],
+        return tf.gather(hidden_graph.node_sets['node']['hidden_state'],
                                                local_context_ids).with_row_splits_dtype(tf.int64)
-
-        # the logits for each local context node to be each local argument
-        # [ batch_size, max(num_arguments), max(num_context_nodes) ]
-        arguments_logits = tf.matmul(hidden_state_sequences,
-                                     context_node_hidden_states.to_tensor(),
-                                     transpose_b=True)
-
-        # a mask for the local context nodes that actually exist
-        # [ batch_size,  max(num_context_nodes) ]
-        context_mask = tf.cast(tf.zeros_like(scalar_proofstate_graph.context['local_context_ids']),
-                               dtype=tf.float32).to_tensor(-float('inf'))
-
-        # the masked logits
-        # [ batch_size, max(num_arguments), max(num_context_nodes) ]
-        return arguments_logits + tf.expand_dims(context_mask, axis=1)
 
     def _hidden_state_sequences(self, hidden_graph: tfgnn.GraphTensor, tactic: tf.Tensor) -> tf.RaggedTensor:
         num_arguments = tf.gather(tf.constant(self._graph_constants.tactic_index_to_numargs, dtype=tf.int64), tactic)
@@ -964,14 +987,21 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
         hidden_state_sequences = self._hidden_state_sequences(hidden_graph=hidden_graph,
                                                               tactic=scalar_proofstate_graph.context['tactic'])
         arg_cnts = hidden_state_sequences.row_lengths()
+        # [batch, None(args), hdim]
         local_hidden_state_sequences = self.local_arguments_head(hidden_state_sequences)
-        local_arguments_logits = self._local_arguments_logits(
+        # [batch, None(context), hdim]
+        local_context_hidden = self._local_context_hidden(
             scalar_proofstate_graph,
             hidden_graph,
-            local_hidden_state_sequences.to_tensor()
         )
+        # [batch_size, None(args), None(context)]
+        local_arguments_logits = QueryKeyMul()(local_hidden_state_sequences, local_context_hidden)
+        # [batch, max(args), max(context)]
+        local_arguments_logits = convert_ragged_logits_to_dense(local_arguments_logits)
         
+        # [batch, None(args), hdim]
         global_hidden_state_sequences = self.global_arguments_head(hidden_state_sequences)
+        # [batch, max(args), context]
         global_arguments_logits = self.global_arguments_logits(global_hidden_state_sequences.to_tensor())  # noqa
         if self._dynamic_global_context:
             global_arguments_logits_mask = self._global_arguments_logits_mask(scalar_proofstate_graph=scalar_proofstate_graph, global_context_size=len(self._graph_constants.global_context))
@@ -1044,13 +1074,21 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
         hidden_graph = repeat_scalar_graph(hidden_graph)  # noqa [ PyCallingNonCallable ]
 
         hidden_state_sequences = self._hidden_state_sequences(hidden_graph=hidden_graph, tactic=tactic)
+        # [batch, None(args), hdim]
         local_hidden_state_sequences = self.local_arguments_head(hidden_state_sequences)
-        local_arguments_logits = self._local_arguments_logits(
+        # [batch, None(context), hdim]
+        local_context_hidden = self._local_context_hidden(
             scalar_proofstate_graph,
             hidden_graph,
-            local_hidden_state_sequences.to_tensor()
         )
+        # [batch_size, None(args), None(context)]
+        local_arguments_logits = QueryKeyMul()(local_hidden_state_sequences, local_context_hidden)
+        # [batch, max(args), max(context)]
+        local_arguments_logits = convert_ragged_logits_to_dense(local_arguments_logits)
+        
+        # [batch, None(args), hdim]
         global_hidden_state_sequences = self.global_arguments_head(hidden_state_sequences)
+        # [batch, max(args), context]
         global_arguments_logits = self.global_arguments_logits(global_hidden_state_sequences.to_tensor())  # noqa
 
         normalized_local_arguments_logits, normalized_global_arguments_logits = self._normalize_logits(

--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -1048,6 +1048,50 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
         norm = -tf.math.log(local_arguments_logits_norm + global_arguments_logits_norm)
         return local_arguments_logits + norm, global_arguments_logits + norm
 
+    def _ragged_log_softmax_double(
+        self,
+        logits0: tf.RaggedTensor,  # [batch_dim, (ragged_dim)]
+        logits1: tf.RaggedTensor,  # [batch_dim, (ragged_dim)]
+    ) -> tuple[tf.RaggedTensor, tf.RaggedTensor]:  # [batch_dim, (ragged_dim)]
+
+        # subtract off max value to make stable 
+        max_logits0 = tf.expand_dims(tf.reduce_max(logits0, axis=-1), -1)  # [total(args), 1]
+        max_logits1 = tf.expand_dims(tf.reduce_max(logits1, axis=-1), -1)  # [total(args), 1]
+        max_logits = tf.maximum(max_logits0, max_logits1)
+        logits0 = logits0 - max_logits  # [batch_dim, (ragged_dim)]
+        logits1 = logits1 - max_logits  # [batch_dim, (ragged_dim)]
+
+        # elementwise exp
+        exp_logits0 = tf.math.exp(logits0)  # [batch_dim, (ragged_dim)]
+        exp_logits1 = tf.math.exp(logits1)  # [batch_dim, (ragged_dim)]
+        sum_exp0 = tf.expand_dims(tf.reduce_sum(exp_logits0, axis=-1), -1)  # [batch_dim, 1]
+        sum_exp1 = tf.expand_dims(tf.reduce_sum(exp_logits1, axis=-1), -1)  # [batch_dim, 1]
+        sum_exp = sum_exp0 + sum_exp1  # [batch_dim, 1]
+
+        # divide in log space to get log probability
+        log_sum = tf.math.log(sum_exp)  # [batch_dim, 1]
+        return (logits0 - log_sum, logits1 - log_sum) # [batch_dim, (ragged_dim)]
+
+    def _log_softmax_logits(
+        self,
+        local_arguments_logits: tf.RaggedTensor,  # [batch, None(args), None(context)]
+        global_arguments_logits: tf.RaggedTensor,  # [batch, None(args), None(context)]
+    ) -> Tuple[tf.RaggedTensor, tf.RaggedTensor]:  # ([batch, None(args), None(context)], [batch, None(args), None(context)])
+        """
+        Normalize local and global arguments logits making sure the log_softmax is numerically stable.
+        """
+        # perform softmax on inner ragged logits
+        # [total(args), None(local_context)], # [total(args), None(global_context)]
+        local_logits_values, global_logits_values = \
+            self._ragged_log_softmax_double(local_arguments_logits.values, global_arguments_logits.values)
+        
+        # shape back into double ragged tensors
+        # [total(args), None(local_context)]
+        local_logits = local_arguments_logits.with_values(local_logits_values)
+        # [total(args), None(global_context)]
+        global_logits = global_arguments_logits.with_values(global_logits_values)
+
+        return local_logits, global_logits
 
     def convert_logits_to_ragged(self, pair) -> tf.RaggedTensor:
         # logits: [batch_size, max(args), context]
@@ -1107,8 +1151,6 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
         )
         # [batch_size, None(args), None(context)]
         local_arguments_logits = QueryKeyMul()(local_hidden_state_sequences, local_context_hidden)
-        # [batch, max(args), max(context)]
-        local_arguments_logits = convert_ragged_logits_to_dense(local_arguments_logits)
         
         # [batch, None(args), hdim]
         global_hidden_state_sequences = self.global_arguments_head(hidden_state_sequences)
@@ -1125,22 +1167,17 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
             _, global_arguments_logits = tf.keras.backend.print_tensor((tf.shape(global_arguments_logits), global_arguments_logits), message="global_arguments_logits")
             global_arguments_logits += tf.expand_dims(global_arguments_logits_mask, axis=1)
 
-        normalized_local_arguments_logits, normalized_global_arguments_logits = self._normalize_logits(local_arguments_logits=local_arguments_logits, global_arguments_logits=global_arguments_logits)
-
         # TODO(jrute): These are temporary conversions from non-ragged to ragged tensors.
-        new_local_arguments_logits = tf.keras.layers.Lambda(self.convert_logits_to_ragged)((
-            normalized_local_arguments_logits, 
-            scalar_proofstate_graph.context['local_context_ids'], 
-            arg_cnts,
-            "local"))
-        new_global_arguments_logits = tf.keras.layers.Lambda(self.convert_logits_to_ragged)((
-            normalized_global_arguments_logits, 
+        global_arguments_logits = tf.keras.layers.Lambda(self.convert_logits_to_ragged)((
+            global_arguments_logits, 
             scalar_proofstate_graph.context['global_context_ids'], 
             arg_cnts,
             "global"))
 
-        local_arguments_logits_output = self.local_arguments_logits_output(new_local_arguments_logits)
-        global_arguments_logits_output = self.global_arguments_logits_output(new_global_arguments_logits)
+        normalized_local_arguments_logits, normalized_global_arguments_logits = self._log_softmax_logits(local_arguments_logits=local_arguments_logits, global_arguments_logits=global_arguments_logits)
+
+        local_arguments_logits_output = self.local_arguments_logits_output(normalized_local_arguments_logits)
+        global_arguments_logits_output = self.global_arguments_logits_output(normalized_global_arguments_logits)
         
         return GlobalArgumentModel(inputs=proofstate_graph,
                                    outputs={self.TACTIC_LOGITS: tactic_logits,

--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -308,6 +308,32 @@ class LocalArgumentModel(tf.keras.Model):
         metric_results[LocalArgumentPrediction.STRICT_ACCURACY] = self.strict_accuracy.result()
         return metric_results
 
+@tf.function
+def arg_best_logit_and_pred(
+    logits: tf.RaggedTensor,  # [batch, None(args), None(context)]
+) -> tuple[tf.RaggedTensor, tf.RaggedTensor]:  # ([batch, None(args)], [batch, None(args)])
+    """Find the value and index of the best arguments logit
+
+    If the context is empty, return -inf for the value and 0 for the index
+
+    :param logits: Logits.  Shape: [batch, None(args), None(context)]
+    :type logits: tf.RaggedTensor
+    :return: value and index of the best logits.  Shape: [batch, None(arg)]
+    :rtype: tuple[tf.RaggedTensor, tf.RaggedTensor]
+    """
+    # pad context with -inf to make rows uniform
+    logits = logits.with_values(logits.values.to_tensor(default_value=-np.inf))  # [batch, None(args), max(context)]
+    if tf.shape(logits.values)[-1] == 0:
+        # best_logit is -inf and pred is 0 if there are no logits
+        template = logits.with_values(logits.value_rowids())  # [batch, None(args)]
+        best_logit = tf.math.log(tf.zeros_like(template, dtype=tf.float32))  # [batch, None(args)]  
+        pred = tf.zeros_like(template, dtype=tf.int64)  # [batch, None(args)]
+    else:
+        # since we pad context with -inf, the best_logit is -inf and pred is 0 if context is empty
+        best_logit = tf.ragged.map_flat_values(tf.reduce_max, logits, axis=-1)  # [batch, None(args)]
+        pred = tf.ragged.map_flat_values(tf.argmax, logits, axis=-1, output_type=tf.int64)  # [batch, None(args)]
+    return (best_logit, pred)
+
 
 class GlobalArgumentModel(tf.keras.Model):
     def __init__(self, **kwargs):
@@ -325,23 +351,16 @@ class GlobalArgumentModel(tf.keras.Model):
         tactic_accuracy = tf.keras.metrics.sparse_categorical_accuracy(tactic, tactic_logits)
 
         # local arguments
-        local_arguments = y[GlobalArgumentPrediction.LOCAL_ARGUMENTS_LOGITS]  # [batch, None(args)]
+        local_arguments = y[GlobalArgumentPrediction.LOCAL_ARGUMENTS_LOGITS]  # [batch, 1, None(args)]
         local_arguments_logits = y_pred[GlobalArgumentPrediction.LOCAL_ARGUMENTS_LOGITS]  # [batch, None(args), None(context]
-        local_arguments_logits = local_arguments_logits.to_tensor(default_value=-np.inf)  # [batch, max(args), context] # FIXME(jrute) 
         local_true = tf.squeeze(local_arguments, 1)  # [batch, None(args)]
-        local_logits = ragged_logits(local_arguments, local_arguments_logits)  # [batch, None(args), context]
-        local_best_logit = tf.ragged.map_flat_values(tf.reduce_max, local_logits, axis=-1)  # [batch, None(args)]
-        local_pred = tf.ragged.map_flat_values(tf.argmax, local_logits, axis=-1, output_type=tf.int64)  # [batch, None(args)]
-        
+        local_best_logit, local_pred = arg_best_logit_and_pred(local_arguments_logits)
         
         # global arguments
-        global_arguments = y[GlobalArgumentPrediction.GLOBAL_ARGUMENTS_LOGITS]  # [batch, None(args)]
+        global_arguments = y[GlobalArgumentPrediction.GLOBAL_ARGUMENTS_LOGITS]  # [batch, 1, None(args)]
         global_arguments_logits = y_pred[GlobalArgumentPrediction.GLOBAL_ARGUMENTS_LOGITS]  # [batch, None(args), None(context]
-        global_arguments_logits = global_arguments_logits.to_tensor(default_value=-np.inf)  # [batch, max(args), context] # FIXME(jrute) 
         global_true = tf.squeeze(global_arguments, 1)  # [batch, None(args)]
-        global_logits = ragged_logits(global_arguments, global_arguments_logits)
-        global_best_logit = tf.ragged.map_flat_values(tf.reduce_max, global_logits, axis=-1)  # [batch, None(args)]
-        global_pred = tf.ragged.map_flat_values(tf.argmax, global_logits, axis=-1, output_type=tf.int64)  # [batch, None(args)]
+        global_best_logit, global_pred = arg_best_logit_and_pred(global_arguments_logits)
 
         # all arguments
         # for ground truth, we can take which ever argument is higher since the other is -1

--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -1236,10 +1236,8 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
             scalar_proofstate_graph,
             hidden_graph,
         )
-        # [batch_size, None(args), None(context)]
+        # [batch, None(args), None(context)]
         local_arguments_logits = QueryKeyMul()(local_hidden_state_sequences, local_context_hidden)
-        # [batch, max(args), max(context)]
-        local_arguments_logits = convert_ragged_logits_to_dense(local_arguments_logits)
         
         # [batch, None(args), hdim]
         global_hidden_state_sequences = self.global_arguments_head(hidden_state_sequences)
@@ -1247,20 +1245,25 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
         global_embeddings = self.global_embeddings(scalar_proofstate_graph.context['global_context_ids'])
         # [batch, None(args), None(context)]
         global_arguments_logits = self.global_logits(queries=global_hidden_state_sequences, keys=global_embeddings)
-        # [batch, max(args), max(context)]
-        global_arguments_logits = convert_ragged_logits_to_dense(global_arguments_logits)
-
-        normalized_local_arguments_logits, normalized_global_arguments_logits = self._normalize_logits(
+        
+        # [batch, None(args), None(context)], [batch, None(args), None(context)]
+        normalized_local_arguments_logits, normalized_global_arguments_logits = self._log_softmax_logits(
             local_arguments_logits=local_arguments_logits,
             global_arguments_logits=global_arguments_logits)
+        
+        # TODO: Temporary
+        # [batch, max(args), max(context)]
+        normalized_local_arguments_logits = convert_ragged_logits_to_dense(normalized_local_arguments_logits)
+        normalized_global_arguments_logits = convert_ragged_logits_to_dense(normalized_global_arguments_logits)
 
+        # [tactic_expand_bound, batch, max(args), max(local_context)]
         normalized_local_arguments_logits = self._reshape_inference_logits(logits=normalized_local_arguments_logits,
                                                                            tactic_expand_bound=tactic_expand_bound)
+        # [tactic_expand_bound, batch, max(args), dynamic_global_context]
         normalized_global_arguments_logits = self._reshape_global_inference_logits(
             logits=normalized_global_arguments_logits,
             tactic_expand_bound=tactic_expand_bound,
             dyn_global_context=scalar_proofstate_graph.context['global_context_ids'])
-                                                                            
 
         return tf.keras.Model(inputs={self.PROOFSTATE_GRAPH: proofstate_graph, self.TACTIC_MASK: tactic_mask},
                               outputs={self.TACTIC: tf.transpose(top_k_indices),

--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -663,7 +663,7 @@ class QueryKeyMul(tf.keras.layers.Layer):
     def _mul_ragged_to_dense_to_ragged(queries, keys):
         queries_dense = queries.to_tensor()    # [batch, max(args), hdim]
         keys_dense = keys.to_tensor()         # [batch, max(context), hdim]
-        logits_dense = tf.einsum("ijl,ikl->ijk", keys_dense, queries_dense)  # [batch, max(args), max(context)]
+        logits_dense = tf.einsum("ijl,ikl->ijk", queries_dense, keys_dense)  # [batch, max(args), max(context)]
         logits_part_ragged = tf.RaggedTensor.from_tensor(logits_dense, lengths=queries.row_lengths())  # [batch, None(args), max(context)]
         lengths = queries.with_values(tf.gather(keys.row_lengths(), queries.value_rowids()))  # [batch, None(args)]
         logits_values = tf.RaggedTensor.from_tensor(logits_part_ragged.values, lengths=lengths.values)
@@ -676,6 +676,8 @@ class QueryKeyMul(tf.keras.layers.Layer):
         keys: tf.RaggedTensor, # [batch, None(context), hdim]
         training=False
     ) -> tf.RaggedTensor: # [batch, None(args), None(context)]
+        queries = queries.with_row_splits_dtype(tf.int64)
+        keys = keys.with_row_splits_dtype(tf.int64)
         if self.method == "map_fn":
             return self._mul_map_fn(queries, keys)
         elif self.method == "broadcast_ragged":

--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -732,12 +732,12 @@ class QueryKeyMulGlobal(tf.keras.layers.Layer):
             self._temp = temp
         self.query_key_mul = QueryKeyMul()
 
-    def normalize_tensor(self, x: tf.Tensor) ->  tf.Tensor:
+    def unit_normalize_tensor(self, x: tf.Tensor) ->  tf.Tensor:
         x_norm = tf.norm(x, axis=-1, keepdims=True)
         return tf.math.divide_no_nan(x, x_norm)
 
-    def normalize_ragged(self, rt: tf.RaggedTensor) -> tf.RaggedTensor:
-        return tf.ragged.map_flat_values(self.normalize_tensor, rt)
+    def unit_normalize_ragged(self, rt: tf.RaggedTensor) -> tf.RaggedTensor:
+        return tf.ragged.map_flat_values(self.unit_normalize_tensor, rt)
 
     def call(
         self, 
@@ -747,8 +747,8 @@ class QueryKeyMulGlobal(tf.keras.layers.Layer):
     ) -> tf.Tensor: # [batch, max(args), context]        
         if self._cosine_similarity:
             # normalize embeddings before taking inner product
-            keys = self.normalize_ragged(keys)
-            queries = self.normalize_ragged(queries)
+            keys = self.unit_normalize_ragged(keys)
+            queries = self.unit_normalize_ragged(queries)
             
         logits = self.query_key_mul(queries, keys)
 
@@ -1047,6 +1047,7 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
         global_arguments_logits_norm = tf.reduce_sum(tf.exp(global_arguments_logits), axis=-1, keepdims=True)
         norm = -tf.math.log(local_arguments_logits_norm + global_arguments_logits_norm)
         return local_arguments_logits + norm, global_arguments_logits + norm
+
 
     def convert_logits_to_ragged(self, pair) -> tf.RaggedTensor:
         # logits: [batch_size, max(args), context]

--- a/tests/unit/test_query_key_mul_layer.py
+++ b/tests/unit/test_query_key_mul_layer.py
@@ -1,0 +1,79 @@
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # force tests to run on CPU
+
+import tensorflow as tf
+
+from graph2tac.tfgnn.tasks import QueryKeyMul
+
+class TestQueryKeyMul:
+    """Test that all methods of QueryKeyMul produces the correct values."""
+    def build_queries_and_keys(self):
+        # [batch, None(args), hdim]
+        self.queries = tf.ragged.constant([
+            [], 
+            [[1.0, 2.0], [3.0, 4.0]], 
+            [[2.0, 3.0],],
+            [[4.0, 5.0], [6.0, 7.0]]
+        ], ragged_rank=1, inner_shape=(2,))
+        
+        # [batch, None(context), hdim]
+        self.keys = tf.ragged.constant([
+            [[1.0, 2.0], [2.0, 3.0]],
+            [],
+            [[2.0, 3.0], [3.0, 4.0]],
+            [[1.0, 2.0]]
+        ], ragged_rank=1, inner_shape=(2,))
+
+        # it is possible to have completely empty queries where there are no arguments in the whole batch
+        # [batch, None(args), hdim]
+        self.queries_empty = tf.ragged.constant([[], [], [], []], ragged_rank=1, inner_shape=(2,))  
+        # it is possible to have completely empty keys where the local context is empty for the whole batch
+        # [batch, None(context), hdim]
+        self.keys_empty = tf.ragged.constant([[], [], [], []], ragged_rank=1, inner_shape=(2,))  
+
+    def query_key_logit_is_correct_value(self, query_key_mul_layer: QueryKeyMul):
+        logits = query_key_mul_layer(queries=self.queries, keys=self.keys)
+        # [batch, None(args), None(context)]
+        correct = tf.ragged.constant([
+            [],  # 0 args, 2 context
+            [[], []],  # 2 args, 0 context
+            [[13.0, 18.0]],  # 1 args, 2 context
+            [[14.0], [20.0]],  # 2 args, 1 context
+        ], ragged_rank=2, inner_shape=())
+        assert logits.to_list() == correct.to_list()
+    
+    def query_empty_key_logit_is_correct_value(self, query_key_mul_layer: QueryKeyMul):
+        logits = query_key_mul_layer(queries=self.queries_empty, keys=self.keys)
+        correct = tf.ragged.constant([[], [], [], []], ragged_rank=2)
+        assert logits.to_list() == correct.to_list()
+    
+    def empty_query_key_logit_is_correct_value(self, query_key_mul_layer: QueryKeyMul):
+        logits = query_key_mul_layer(queries=self.queries, keys=self.keys_empty)
+        correct = tf.ragged.constant([[], [[],[]], [[]], [[], []]], ragged_rank=2)
+        assert logits.to_list() == correct.to_list()
+
+    def empty_query_empty_key_logit_is_correct_value(self, query_key_mul_layer: QueryKeyMul):
+        logits = query_key_mul_layer(queries=self.queries_empty, keys=self.keys_empty)
+        correct = tf.ragged.constant([[], [], [], []], ragged_rank=2)
+        assert logits.to_list() == correct.to_list()
+
+    def all_logits_are_correct_values(self, query_key_mul_layer: QueryKeyMul):
+        self.build_queries_and_keys()
+        self.query_key_logit_is_correct_value(query_key_mul_layer)
+        self.empty_query_key_logit_is_correct_value(query_key_mul_layer)
+
+    def test_default_method(self):
+        self.all_logits_are_correct_values(QueryKeyMul())
+    
+    def test_map_fn(self):
+        self.all_logits_are_correct_values(QueryKeyMul(method="map_fn"))
+    
+    def test_broadcast_ragged(self):
+        self.all_logits_are_correct_values(QueryKeyMul(method="broadcast_ragged"))
+
+    def test_ragged_to_tensor_to_ragged(self):
+        self.all_logits_are_correct_values(QueryKeyMul(method="ragged_to_dense_to_ragged"))
+
+        
+        
+


### PR DESCRIPTION
This is the second PR in a series of PRs to speed up the model and reduce the memory requirements.  It refactors major parts of the argument prediction code, and is enough to start training on a large dataset.

The tests all pass.  (A unit test was added for the new `QueryKeyMul` layer which multiplies the queries and keys into logits.  This was an expensive computation and it required a lot of optimization.  This ensures the optimizations do the write calculations, and lets us even further optimize it if needed.)

Work to still be done in future PRs.  Probably none of these are necessary to train and benchmark the model, so it might be enough to start large runs now.  But here are some possible things we could do before that.  Note, if we do this later, we might have to retrain a model to be compatible with the new code.  We should add some tests that check for compatibility with already training models to know if we are making breaking changes.
- [ ] Make the prediction network return a ragged tensor (and refactor the prediction code to use that tensor instead).  This would likely speed up some parts of the predict server.
- [ ] Optimize the prediction network for speed/memory.
- [ ] Delete useless code (can be done at any time and isn't a blocker)
- [ ] Streamline some of the code.  (Currently, this new code is a bit convoluted at parts, with layers calling layers, etc.  It would be good to clean it up, but not needed.) 