### PR TITLE
Quick speedup to inference

### DIFF
--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -670,8 +670,10 @@ class GlobalEmbeddings(tf.keras.layers.Layer):
         # note: inference model always uses dynamic global context
         if self.dynamic_global_context or inference:
             # select the global context for each batch
+            # this is equivalent to `tf.gather(all_embeddings, global_context)`
+            # but *much faster* when inference is run on CPU
             # [batch, None(context), hdim]
-            return tf.gather(all_embeddings, global_context)
+            return global_context.with_values(tf.gather(all_embeddings, global_context.values))
         else:
             # currently this would mess up later indexing
             raise NotImplementedError("dynamical_global_context must be set to true")


### PR DESCRIPTION
This is a very simple change which speeds up the inference part of the predict server.  Indeed 80% of the computation spent in the neural network for inference (on CPU) was in this one line for some weird reason.  The new line is equivalent, and I don't understand why it is so much faster on the CPU. 🤷 

For my test cases this allows us to do say 600 messages per minute instead of 500.

(Note, the 80% above refers to the neural network part running the inference model.  There is a significant amount of time, much more than the neural network, spent calculating the highest scoring results based on the networks outputs.  My next step is to tackle that part of the code.)