### PR TITLE
Increase recursion limit of g2t-server to 10000

### DIFF
--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -813,7 +813,7 @@ def load_model(config: argparse.Namespace, log_levels: dict) -> Predict:
     return model
 
 def main() -> ResponseHistory:
-
+    sys.setrecursionlimit(10000)
     config = parse_args()
 
     if config.record is not None:


### PR DESCRIPTION
Some Coq files are slightly too big for the default limit of 1000.