### PR TITLE
Speedup inference model

### DIFF
--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -793,7 +793,6 @@ class QueryKeyMul(tf.keras.layers.Layer):
         then compute inner product on value tensors directly.
         """
         tf.assert_equal(tf.shape(keys)[0], 1)
-        tf.print("SINGLETON")
 
         query_values = queries.values  # [args, hdim]
         key_values = keys.values  # [context, hdim]

--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -955,10 +955,14 @@ class LocalArgumentPrediction(TacticPrediction):
         return self.arguments_head((hidden_graph, self.tactic_embedding(tactic), num_arguments))
 
     @staticmethod
-    def _reshape_inference_logits(logits: tf.Tensor, tactic_expand_bound: int) -> tf.Tensor:
+    def _reshape_inference_logits(
+        logits: tf.Tensor,  # [batch*tactic_expand_bound, max(args), max(cxt)]
+        tactic_expand_bound: int  
+    ) -> tf.Tensor:  # [batch, tactic_expand_bound, max(args), max(cxt)]
         num_arguments = tf.shape(logits)[1]
         num_logits = tf.shape(logits)[2]
-        return tf.reshape(logits, shape=(tactic_expand_bound, -1, num_arguments, num_logits))
+        # [batch, tactic_expand_bound, max(args), max(cxt)]
+        return tf.reshape(logits, shape=(-1, tactic_expand_bound, num_arguments, num_logits))
 
     def create_train_model(self) -> tf.keras.Model:
         """
@@ -1206,6 +1210,37 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
 
         return local_logits, global_logits
 
+    @staticmethod
+    def transpose_ragged_first_dim(
+        x: tf.RaggedTensor,  # [outer*inner, None(ragged), ...]
+        outer_dim: int,
+        inner_dim: int,
+    ) -> tf.RaggedTensor:  # [inner*outer, None(ragged), ...]
+        """
+        Convert a ragged tensor of shape `[outer*inner, None(ragged), ...]`
+        to one of shape `[inner*outer, None(ragged), ...]`
+        by permuting the inner values.
+        """
+        inner_dim = tf.cast(inner_dim, dtype=tf.int64)
+        outer_dim = tf.cast(outer_dim, dtype=tf.int64)
+
+        # calculate new row ids
+        rowids = x.value_rowids()  # [outer-inner-ragged]
+        batch1_rowids = rowids // inner_dim  # [outer-inner-ragged]
+        batch2_rowids = rowids % inner_dim   # [outer-inner-ragged]
+        new_rowids = batch2_rowids * outer_dim + batch1_rowids  # [outer-inner-ragged]
+        
+        # reorder the elements according to the new row ids
+        new_order = tf.argsort(new_rowids)  # [inner-outer-ragged]
+        new_rowids = tf.sort(new_rowids)  # [inner-outer-ragged]
+
+        # [inner*outer, None(ragged), ...]
+        return tf.RaggedTensor.from_value_rowids(
+            values=tf.gather(x.values, new_order),  # [inner-outer-ragged, ...]
+            value_rowids=new_rowids,  # [inner-outer-ragged]
+            nrows=inner_dim * outer_dim
+        )
+
     def create_train_model(self) -> tf.keras.Model:
         """
         Combines a GNN component with a tactic head and an arguments head to produce an end-to-end model for the
@@ -1281,66 +1316,94 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
         proofstate_tactic_mask = tf.where(tf.expand_dims(no_context_proofstates, axis=-1),
                                           tf.expand_dims(no_argument_tactics_mask, axis=0),
                                           tf.expand_dims(all_tactics_mask, axis=0))
-
+        # [batch_size, tactic_expand_bound], [batch_size, tactic_expand_bound] 
         top_k_indices, top_k_values = self._top_k_tactics(tactic_logits=tactic_logits,
                                                           tactic_mask=proofstate_tactic_mask & tactic_mask,
                                                           tactic_expand_bound=tactic_expand_bound)
-
+        # [tactic_expand_bound*batch_size]
         tactic = tf.reshape(tf.transpose(top_k_indices), shape=(tf.size(top_k_indices),))
 
+        # [batch_size, None(context), hdim]
+        local_context_hidden = self._local_context_hidden(
+            scalar_proofstate_graph,
+            hidden_graph,
+        )
         # [batch_size, None(context), hdim]
         global_embeddings = self.global_embeddings(
             scalar_proofstate_graph.context['global_context_ids'],
             inference=True
         )
+        
+        batch_size = tf.shape(top_k_indices)[0]
 
         repeat_scalar_graph = RepeatScalarGraph(num_repetitions=tactic_expand_bound)
-        scalar_proofstate_graph = repeat_scalar_graph(scalar_proofstate_graph)  # noqa [ PyCallingNonCallable ]
+        # dimension of component features: [tactic_expand_bound*batch, ...]
         hidden_graph = repeat_scalar_graph(hidden_graph)  # noqa [ PyCallingNonCallable ]
-
+        # [tactic_expand_bound*batch, None(args), hdim]
         hidden_state_sequences = self._hidden_state_sequences(hidden_graph=hidden_graph, tactic=tactic)
-        # [tactic_expand_bound*batch, None(args), hdim]
+        # [batch*tactic_expand_bound, None(args), hdim]
+        hidden_state_sequences = self.transpose_ragged_first_dim(
+            hidden_state_sequences, 
+            outer_dim=tactic_expand_bound, 
+            inner_dim=batch_size
+        )
+        # [batch*tactic_expand_bound]
+        tactic_arg_cnt = hidden_state_sequences.row_lengths()
+        # [batch]
+        batch_arg_cnt = tf.reduce_sum(tf.reshape(tactic_arg_cnt, shape=[batch_size, tactic_expand_bound]), axis=-1)
+        
+        # [batch*tactic_expand_bound, None(args), hdim]
         local_hidden_state_sequences = self.local_arguments_head(hidden_state_sequences)
-        # [tactic_expand_bound*batch, None(context), hdim]
-        local_context_hidden = self._local_context_hidden(
-            scalar_proofstate_graph,
-            hidden_graph,
+        # [batch, None(tactic_expand_bound*args), hdim]
+        local_hidden_state_sequences = tf.RaggedTensor.from_row_lengths(
+            values=local_hidden_state_sequences.values,  # [batch-tactic-arg, hdim]
+            row_lengths=batch_arg_cnt
         )
-        # [tactic_expand_bound*batch, None(args), None(context)]
+        # [batch, None(tactic_expand_bound*args), None(context)]
         local_arguments_logits = QueryKeyMul()(local_hidden_state_sequences, local_context_hidden)
-        
-        # [tactic_expand_bound*batch, None(args), hdim]
-        global_hidden_state_sequences = self.global_arguments_head(hidden_state_sequences)
-        # [tactic_expand_bound*batch, None(context), hdim]
-        global_embeddings = tf.RaggedTensor.from_row_lengths(
-            values=tf.tile(global_embeddings.values, multiples=[tactic_expand_bound, 1]),
-            row_lengths=tf.tile(global_embeddings.row_lengths(), multiples=[tactic_expand_bound])
+        # [batch*tactic_expand_bound, None(args), None(context)]
+        local_arguments_logits = tf.RaggedTensor.from_row_lengths(
+            values=local_arguments_logits.values,  # [batch-tactic-arg, None(context)]
+            row_lengths=tactic_arg_cnt
         )
-        # [tactic_expand_bound*batch, None(args), None(context)]
-        global_arguments_logits = self.global_logits(queries=global_hidden_state_sequences, keys=global_embeddings)
         
-        # [tactic_expand_bound*batch, None(args), None(context)], [batch, None(args), None(context)]
+        # [batch*tactic_expand_bound, None(args), hdim]
+        global_hidden_state_sequences = self.global_arguments_head(hidden_state_sequences)
+        # [batch, None(tactic_expand_bound*args), hdim]
+        global_hidden_state_sequences = tf.RaggedTensor.from_row_lengths(
+            values=global_hidden_state_sequences.values,  # [batch-tactic-arg, None(context)]
+            row_lengths=batch_arg_cnt
+        )
+        # [batch, None(tactic_expand_bound*args), None(context)]
+        global_arguments_logits = self.global_logits(queries=global_hidden_state_sequences, keys=global_embeddings)
+        # [batch*tactic_expand_bound, None(args), None(context)]
+        global_arguments_logits = tf.RaggedTensor.from_row_lengths(
+            values=global_arguments_logits.values,  # [batch-tactic-arg, None(context)]
+            row_lengths=tactic_arg_cnt
+        )
+        
+        # [batch*tactic_expand_bound, None(args), None(context)], [batch*tactic_expand_bound, None(args), None(context)]
         normalized_local_arguments_logits, normalized_global_arguments_logits = self._log_softmax_logits(
             local_arguments_logits=local_arguments_logits,
             global_arguments_logits=global_arguments_logits)
         
         # TODO: Temporary
-        # [tactic_expand_bound*batch, max(args), max(context)]
+        # [batch*tactic_expand_bound, max(args), max(context)]
         normalized_local_arguments_logits = convert_ragged_logits_to_dense(normalized_local_arguments_logits)
         normalized_global_arguments_logits = convert_ragged_logits_to_dense(normalized_global_arguments_logits)
 
-        # [tactic_expand_bound, batch, max(args), max(local_context)]
+        # [batch, tactic_expand_bound, max(args), max(local_context)]
         normalized_local_arguments_logits = self._reshape_inference_logits(logits=normalized_local_arguments_logits,
                                                                            tactic_expand_bound=tactic_expand_bound)
-        # [tactic_expand_bound, batch, max(args), dynamic_global_context]
+        # [batch, tactic_expand_bound, max(args), dynamic_global_context]
         normalized_global_arguments_logits = self._reshape_inference_logits(logits=normalized_global_arguments_logits,
                                                                            tactic_expand_bound=tactic_expand_bound)
 
         return tf.keras.Model(inputs={self.PROOFSTATE_GRAPH: proofstate_graph, self.TACTIC_MASK: tactic_mask},
                               outputs={self.TACTIC: tf.transpose(top_k_indices),
                                        self.TACTIC_LOGITS: tf.transpose(top_k_values),
-                                       self.LOCAL_ARGUMENTS_LOGITS: normalized_local_arguments_logits,
-                                       self.GLOBAL_ARGUMENTS_LOGITS: normalized_global_arguments_logits})
+                                       self.LOCAL_ARGUMENTS_LOGITS: tf.transpose(normalized_local_arguments_logits, perm=[1, 0, 2, 3]),
+                                       self.GLOBAL_ARGUMENTS_LOGITS: tf.transpose(normalized_global_arguments_logits, perm=[1, 0, 2, 3])})
 
     @staticmethod
     def create_input_output(graph_tensor: tfgnn.GraphTensor) -> Tuple[


### PR DESCRIPTION
This PR *significantly* speeds up the neural network part of inference.  (It still doesn't address beam search which is coming in another PR.)  The idea is a continuation of the previous PR as follows.  After computing the graph embeddings, we choose `k` tactics, and compute arguments for those tactics.  However, the available local and global context is independent from the chosen tactics.  So this allows for three optimizations:
* The keys (local and global context embeddings) can be computed before we do anything with tactics.   They only need to have shape `[batch, None(cxt), hdim]` where `batch` is the original batch size (1 in our case).
* The queries on the other hand, do depend on the tactics, but can still match them up with the keys, by listing all tactic-argument embeddings or all `k` tactics under the same batch element.  The queries then have ragged shape `[batch, None(tactic-args), hdim]`, where `batch` is just the original batch_size (in our case 1).
* Finally, since the batch dimension is size one in our case, the arrays I mentioned above are not really ragged, so in that special case of batch_size=1, we can optimize the multiplication to just be regular matrix multiplication (with no ragged tensor issues).

These three optimizations, when combined, significantly speed up the model.  Previously, most of the time was spent multiplying queries and keys to get the logits (or transforming tensors to get into and out of the right shape to multiply).  This eliminates all that.  And moreover, surprisingly to me, by reducing the shape of the key tensor, we also significantly speed up even the time spent on the einsum operator (even though we still multiply the same number of query-key pairs together).