### PR TITLE
Mirek/graph constants json

### DIFF
--- a/graph2tac/loader/data_classes.py
+++ b/graph2tac/loader/data_classes.py
@@ -94,7 +94,7 @@ class DatasetConfig:
     shuffle_random_seed : int
 
 @dataclass
-class GraphConstantsRaw:
+class GraphConstants:
     data_config : DataConfig
     tactic_num: int
     edge_label_num: int
@@ -107,10 +107,3 @@ class GraphConstantsRaw:
     label_to_names: list[str]
     label_to_ident: list[int]
     label_in_spine: list[bool]
-
-# A trick to allow "global_context" being a parameter without storing it anywhere
-# It can be removed with renaming "GraphConstantsRaw" -> "GraphConstants" if we decide
-# that we don't need to use old models anymore (or delete "global_context" from them)
-class GraphConstants(GraphConstantsRaw):
-    def __init__(self, *args, global_context=None, **kwargs):
-        super().__init__(*args, **kwargs)

--- a/graph2tac/tfgnn/predict.py
+++ b/graph2tac/tfgnn/predict.py
@@ -163,7 +163,7 @@ class TFGNNPredict(Predict):
         if not graph_constants_filepath_json.exists():
             logger.info(f'no json graph_constants file, trying to load yaml')
             with graph_constants_filepath_yaml.open('r') as yml_file:
-                graph_constants_d = yaml.load(yml_file, Loader=yaml.UnsafeLoader)
+                graph_constants_d = yaml.load(yml_file, Loader=yaml.SafeLoader)
             if "global_context" in graph_constants_d:
                 global_context = graph_constants_d["global_context"]
                 assert global_context == list(range(len(global_context)))


### PR DESCRIPTION
As discussed, saves / loads `graph_constants` as `json`. Comments:
* There is a potential issue with the test `load_previous_model` -- since the current code saves `json` in case of loading `yaml`, it will save this `json` to this test, so the next run of the test is not testing as far reaching backward compatibility as before. If we want to be more rigorous about this, we could delete `graph_constants.json` after / before each run of the test.
* I moved discarding possible redundant `global_context` from `data_classes.py / GraphConstants` to the point where it is loaded from `yaml` / converted to `json`.