### PR TITLE
Support python3.8 through 3.10

### DIFF
--- a/graph2tac/loader/data_classes.py
+++ b/graph2tac/loader/data_classes.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, Any
+from typing import Optional, Any, List
 import tensorflow as tf
 from collections import namedtuple
 
@@ -101,9 +101,9 @@ class GraphConstants:
     base_node_label_num: int
     node_label_num: int
     cluster_subgraphs_num: int
-    tactic_index_to_numargs: list[int]
-    tactic_index_to_string: list[str]    # tactic names
-    tactic_index_to_hash: list[int]
-    label_to_names: list[str]
-    label_to_ident: list[int]
-    label_in_spine: list[bool]
+    tactic_index_to_numargs: List[int]
+    tactic_index_to_string: List[str]    # tactic names
+    tactic_index_to_hash: List[int]
+    label_to_names: List[str]
+    label_to_ident: List[int]
+    label_in_spine: List[bool]

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import sys
 import socket
 from pathlib import Path
-from typing import BinaryIO, Optional
+from typing import BinaryIO, Optional, Union
 import numpy as np
 from numpy.typing import NDArray, ArrayLike
 import tqdm
@@ -73,7 +73,7 @@ class ResponseHistory:
         return str
 
     @staticmethod
-    def convert_msg_to_dict(msg: CheckAlignmentResponse | TacticPredictionsGraph) -> dict:
+    def convert_msg_to_dict(msg: Union[CheckAlignmentResponse, TacticPredictionsGraph]) -> dict:
         if isinstance(msg, TacticPredictionsGraph):
             return {
                 "_type": type(msg).__name__,
@@ -95,7 +95,7 @@ class ResponseHistory:
         else:
             raise NotImplementedError(f"f{type(msg)} messages not yet supported")
     
-    def record_response(self, msg: CheckAlignmentResponse | TacticPredictionsGraph):
+    def record_response(self, msg: Union[CheckAlignmentResponse, TacticPredictionsGraph]):
         if self._recording_on:
             self.data["responses"].append(self.convert_msg_to_dict(msg))
 

--- a/graph2tac/loader/predict_server.py
+++ b/graph2tac/loader/predict_server.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import sys
 import socket
 from pathlib import Path
-from typing import BinaryIO, Optional, Union
+from typing import BinaryIO, Optional, Union, Dict
 import numpy as np
 from numpy.typing import NDArray, ArrayLike
 import tqdm
@@ -103,12 +103,12 @@ class Profiler:
     """
     Controls the tensorflow profiler for both profiling predictions and definitions
     """
-    logdir: dict[str, Path]
-    start: dict[str, int]
-    end: dict[str, int]
-    cnt: dict[str, int]
+    logdir: Dict[str, Path]
+    start: Dict[str, int]
+    end: Dict[str, int]
+    cnt: Dict[str, int]
 
-    def __init__(self, logdir: dict[str, Optional[Path]], start: dict[str, int], end: dict[str, int]):
+    def __init__(self, logdir: Dict[str, Optional[Path]], start: Dict[str, int], end: Dict[str, int]):
         self.logdir = {k: v for k,v in logdir.items() if v is not None}
         self.start = start
         self.end = end

--- a/graph2tac/tfgnn/predict.py
+++ b/graph2tac/tfgnn/predict.py
@@ -44,11 +44,11 @@ class BeamSearch(tf.keras.layers.Layer):
     def __init__(
         self, 
         token_log_prob_fn: Callable[
-            [tf.Tensor, tf.Tensor, dict[str, tf.Tensor], dict[str, tf.Tensor | tf.RaggedTensor]],
+            [tf.Tensor, tf.Tensor, dict[str, tf.Tensor], dict[str, Union[tf.Tensor, tf.RaggedTensor]]],
             tuple[tf.Tensor, dict[str, tf.Tensor]]
         ], 
         stopping_fn: Callable[
-            [tf.Tensor, tf.Tensor, dict[str, tf.Tensor], dict[str, tf.Tensor | tf.RaggedTensor]],
+            [tf.Tensor, tf.Tensor, dict[str, tf.Tensor], dict[str, Union[tf.Tensor, tf.RaggedTensor]]],
             tuple[tf.Tensor, dict[str, tf.Tensor]]
         ],
     ):
@@ -61,7 +61,7 @@ class BeamSearch(tf.keras.layers.Layer):
         ids: tf.Tensor,  # [batch_size, beam_size0, seq_length]
         scores: tf.Tensor,  # [batch_size, beam_size0]
         cache: dict[str, tf.Tensor],  # dict with values: [batch_size, beam_size0, ...]
-        static_data: dict[str, tf.Tensor | tf.RaggedTensor],
+        static_data: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
         i: tf.Tensor,  # int32
         max_beam_size: tf.Tensor,  # int32
     ) -> tuple[
@@ -106,7 +106,7 @@ class BeamSearch(tf.keras.layers.Layer):
         ids: tf.Tensor,  # [batch_size, beam_size0, seq_length]
         scores: tf.Tensor,  # [batch_size, beam_size0]
         cache: dict[str, tf.Tensor],  # dict with values: [batch_size, beam_size0, ...]
-        static_data: dict[str, tf.Tensor | tf.RaggedTensor],
+        static_data: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
         i: tf.Tensor,  # int32
         max_beam_size: tf.Tensor,  # int32                           
     ) -> tuple[
@@ -131,7 +131,7 @@ class BeamSearch(tf.keras.layers.Layer):
         self,
         initial_ids: tf.Tensor,  # [batch_size, initial_seq_length]
         initial_cache: dict[str, tf.Tensor],  # [batch_size, ...]
-        static_data: dict[str, tf.Tensor | tf.RaggedTensor],
+        static_data: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
         beam_size: tf.Tensor,  # int32
         max_decode_length: tf.Tensor,  # int32
     ) -> tuple[tf.Tensor, tf.Tensor]:
@@ -199,7 +199,7 @@ class SelectBestResults(tf.keras.layers.Layer):
         partial_seqs: tf.Tensor,  # [batch, beam_size, seq_length] dtype: int
         pos: tf.Tensor,  # scalar dtype: int32,
         cache: dict[str, tf.Tensor],  # value shapes: [batch, beam_size, ...]
-        static_data: dict[str, tf.Tensor | tf.RaggedTensor]
+        static_data: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
     ) -> tuple[tf.Tensor, dict[str, tf.Tensor]]:  # output shapes [batch, beam_size, vocab], dict of [batch, beam_size, ...]
         if pos == 0:
             # look up tactic logits
@@ -230,7 +230,7 @@ class SelectBestResults(tf.keras.layers.Layer):
         partial_seqs: tf.Tensor,  # [batch, beam_size, seq_length] dtype: int
         pos: tf.Tensor,  # scalar dtype: int32,
         cache: dict[str, tf.Tensor],  # value shapes: [batch, beam_size, ...]
-        static_data: dict[str, tf.Tensor | tf.RaggedTensor]
+        static_data: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
     ) -> tuple[tf.Tensor, dict[str, tf.Tensor]]:  # output shapes [batch, beam_size], dict of [batch, beam_size, ...]
         if pos == 0:
             is_finished = tf.zeros(shape=tf.shape(partial_seqs)[:2], dtype=bool)  # [batch, beam_size]
@@ -462,7 +462,7 @@ class SelectBestResults(tf.keras.layers.Layer):
 
     def call(
         self,
-        inference_output: dict[str, tf.Tensor | tf.RaggedTensor],
+        inference_output: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
     ):
         tactics = inference_output["tactic"]  # [batch, top_k_tactics]
         tactic_logits = inference_output["tactic_logits"]  # [batch, top_k_tactics]

--- a/graph2tac/tfgnn/predict.py
+++ b/graph2tac/tfgnn/predict.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Union, Iterable, Callable, Optional
+from typing import Tuple, List, Union, Iterable, Callable, Optional, Dict
 
 import re
 import yaml
@@ -44,12 +44,12 @@ class BeamSearch(tf.keras.layers.Layer):
     def __init__(
         self, 
         token_log_prob_fn: Callable[
-            [tf.Tensor, tf.Tensor, dict[str, tf.Tensor], dict[str, Union[tf.Tensor, tf.RaggedTensor]]],
-            tuple[tf.Tensor, dict[str, tf.Tensor]]
+            [tf.Tensor, tf.Tensor, Dict[str, tf.Tensor], Dict[str, Union[tf.Tensor, tf.RaggedTensor]]],
+            Tuple[tf.Tensor, Dict[str, tf.Tensor]]
         ], 
         stopping_fn: Callable[
-            [tf.Tensor, tf.Tensor, dict[str, tf.Tensor], dict[str, Union[tf.Tensor, tf.RaggedTensor]]],
-            tuple[tf.Tensor, dict[str, tf.Tensor]]
+            [tf.Tensor, tf.Tensor, Dict[str, tf.Tensor], Dict[str, Union[tf.Tensor, tf.RaggedTensor]]],
+            Tuple[tf.Tensor, Dict[str, tf.Tensor]]
         ],
     ):
         super().__init__()
@@ -60,14 +60,14 @@ class BeamSearch(tf.keras.layers.Layer):
         self,
         ids: tf.Tensor,  # [batch_size, beam_size0, seq_length]
         scores: tf.Tensor,  # [batch_size, beam_size0]
-        cache: dict[str, tf.Tensor],  # dict with values: [batch_size, beam_size0, ...]
-        static_data: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
+        cache: Dict[str, tf.Tensor],  # dict with values: [batch_size, beam_size0, ...]
+        static_data: Dict[str, Union[tf.Tensor, tf.RaggedTensor]],
         i: tf.Tensor,  # int32
         max_beam_size: tf.Tensor,  # int32
-    ) -> tuple[
+    ) -> Tuple[
         tf.Tensor,  # ids: [batch_size, beam_size, seq_length+1]
         tf.Tensor,  # scores: [batch_size, beam_size]
-        dict[str, tf.Tensor],  # cache with values: [batch_size, beam_size, ...]
+        Dict[str, tf.Tensor],  # cache with values: [batch_size, beam_size, ...]
     ]:
         batch_size = tf.shape(ids)[0]
         beam_size0 = tf.shape(ids)[1]
@@ -105,14 +105,14 @@ class BeamSearch(tf.keras.layers.Layer):
         is_finished: tf.Tensor, # bool
         ids: tf.Tensor,  # [batch_size, beam_size0, seq_length]
         scores: tf.Tensor,  # [batch_size, beam_size0]
-        cache: dict[str, tf.Tensor],  # dict with values: [batch_size, beam_size0, ...]
-        static_data: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
+        cache: Dict[str, tf.Tensor],  # dict with values: [batch_size, beam_size0, ...]
+        static_data: Dict[str, Union[tf.Tensor, tf.RaggedTensor]],
         i: tf.Tensor,  # int32
         max_beam_size: tf.Tensor,  # int32                           
-    ) -> tuple[
+    ) -> Tuple[
         tf.Tensor,  # ids: [batch_size, beam_size, seq_length+1]
         tf.Tensor,  # scores: [batch_size, beam_size]
-        dict[str, tf.Tensor],  # cache with values: [batch_size, beam_size, ...]
+        Dict[str, tf.Tensor],  # cache with values: [batch_size, beam_size, ...]
     ]:
         if is_finished:
             return (is_finished, (ids, scores, cache))
@@ -130,11 +130,11 @@ class BeamSearch(tf.keras.layers.Layer):
     def call(
         self,
         initial_ids: tf.Tensor,  # [batch_size, initial_seq_length]
-        initial_cache: dict[str, tf.Tensor],  # [batch_size, ...]
-        static_data: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
+        initial_cache: Dict[str, tf.Tensor],  # [batch_size, ...]
+        static_data: Dict[str, Union[tf.Tensor, tf.RaggedTensor]],
         beam_size: tf.Tensor,  # int32
         max_decode_length: tf.Tensor,  # int32
-    ) -> tuple[tf.Tensor, tf.Tensor]:
+    ) -> Tuple[tf.Tensor, tf.Tensor]:
         batch_size = tf.shape(initial_ids)[0]
 
         # start with a beam_size of 1 for the input to the first step first step
@@ -184,7 +184,7 @@ class SelectBestResults(tf.keras.layers.Layer):
     :param tactic_index_to_numargs: list tactic arg lengths for each tactic
     :param search_expand_bound: maximum number of results to return
     """
-    def __init__(self, tactic_index_to_numargs: list[int], search_expand_bound: int):
+    def __init__(self, tactic_index_to_numargs: List[int], search_expand_bound: int):
         super().__init__()
         self.tactic_index_to_numargs = tf.cast(tf.constant(tactic_index_to_numargs), tf.int32)
         self.search_expand_bound = search_expand_bound
@@ -198,9 +198,9 @@ class SelectBestResults(tf.keras.layers.Layer):
         self,
         partial_seqs: tf.Tensor,  # [batch, beam_size, seq_length] dtype: int
         pos: tf.Tensor,  # scalar dtype: int32,
-        cache: dict[str, tf.Tensor],  # value shapes: [batch, beam_size, ...]
-        static_data: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
-    ) -> tuple[tf.Tensor, dict[str, tf.Tensor]]:  # output shapes [batch, beam_size, vocab], dict of [batch, beam_size, ...]
+        cache: Dict[str, tf.Tensor],  # value shapes: [batch, beam_size, ...]
+        static_data: Dict[str, Union[tf.Tensor, tf.RaggedTensor]],
+    ) -> Tuple[tf.Tensor, Dict[str, tf.Tensor]]:  # output shapes [batch, beam_size, vocab], dict of [batch, beam_size, ...]
         if pos == 0:
             # look up tactic logits
             batch_ix = cache["batch_ix"]  # [batch, beam_size]
@@ -229,9 +229,9 @@ class SelectBestResults(tf.keras.layers.Layer):
         self,
         partial_seqs: tf.Tensor,  # [batch, beam_size, seq_length] dtype: int
         pos: tf.Tensor,  # scalar dtype: int32,
-        cache: dict[str, tf.Tensor],  # value shapes: [batch, beam_size, ...]
-        static_data: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
-    ) -> tuple[tf.Tensor, dict[str, tf.Tensor]]:  # output shapes [batch, beam_size], dict of [batch, beam_size, ...]
+        cache: Dict[str, tf.Tensor],  # value shapes: [batch, beam_size, ...]
+        static_data: Dict[str, Union[tf.Tensor, tf.RaggedTensor]],
+    ) -> Tuple[tf.Tensor, Dict[str, tf.Tensor]]:  # output shapes [batch, beam_size], dict of [batch, beam_size, ...]
         if pos == 0:
             is_finished = tf.zeros(shape=tf.shape(partial_seqs)[:2], dtype=bool)  # [batch, beam_size]
             return is_finished, cache
@@ -253,7 +253,7 @@ class SelectBestResults(tf.keras.layers.Layer):
         tactic_arg_counts: tf.Tensor,  # [batch, tactics] dtype:int32
         arg_logits: tf.RaggedTensor,  # [batch * tactics, None(args), small_cxt] 
         beam_width: tf.Tensor,  # int32
-    ) -> tuple[
+    ) -> Tuple[
         tf.Tensor,  # tactic_token [batch-beam]
         tf.RaggedTensor,  # arg_token [batch-beam, None(args)]
         tf.Tensor,  # log_probs [batch-beam]
@@ -309,7 +309,7 @@ class SelectBestResults(tf.keras.layers.Layer):
         tactic_arg_counts: tf.Tensor,  # [batch, tactics] dtype:int32
         arg_logits: tf.RaggedTensor,  # [batch * tactics, None(args), small_cxt] 
         beam_width: tf.Tensor,  # int32
-    ) -> tuple[
+    ) -> Tuple[
         tf.Tensor,  # tactic [batch-beam]
         tf.RaggedTensor,  # arg_ix [batch, None(args)]
         tf.Tensor,  # log_probs [batch-beam]
@@ -365,7 +365,7 @@ class SelectBestResults(tf.keras.layers.Layer):
         tactic_arg_counts: tf.Tensor,  # [batch, tactics] dtype:int32
         arg_logits: tf.RaggedTensor,  # [batch * tactics, None(args), cxt] 
         beam_width: tf.Tensor,  # int32
-    ) -> tuple[
+    ) -> Tuple[
         tf.Tensor,  # tactic [batch-beam]
         tf.RaggedTensor,  # arg_ix [batch, None(args)]
         tf.Tensor,  # log_probs [batch-beam]
@@ -412,7 +412,7 @@ class SelectBestResults(tf.keras.layers.Layer):
         local_arg_logits: tf.RaggedTensor,  # [batch * tactics, None(args), global_cxt]
         global_arg_logits: tf.RaggedTensor,  # [batch * tactics, None(args), local_cxt]
         beam_width: tf.Tensor,  # int32
-    ) -> tuple[
+    ) -> Tuple[
         tf.RaggedTensor,  # log_probs [batch, None(options)]
         tf.RaggedTensor,  # log_probs [batch, None(options), None(tactic+args), 2]
     ]:
@@ -462,7 +462,7 @@ class SelectBestResults(tf.keras.layers.Layer):
 
     def call(
         self,
-        inference_output: dict[str, Union[tf.Tensor, tf.RaggedTensor]],
+        inference_output: Dict[str, Union[tf.Tensor, tf.RaggedTensor]],
     ):
         tactics = inference_output["tactic"]  # [batch, top_k_tactics]
         tactic_logits = inference_output["tactic_logits"]  # [batch, top_k_tactics]

--- a/graph2tac/tfgnn/tasks.py
+++ b/graph2tac/tfgnn/tasks.py
@@ -231,7 +231,7 @@ class LocalArgumentModel(tf.keras.Model):
 @tf.function
 def arg_best_logit_and_pred(
     logits: tf.RaggedTensor,  # [batch, None(args), None(context)]
-) -> tuple[tf.RaggedTensor, tf.RaggedTensor]:  # ([batch, None(args)], [batch, None(args)])
+) -> Tuple[tf.RaggedTensor, tf.RaggedTensor]:  # ([batch, None(args)], [batch, None(args)])
     """Find the value and index of the best arguments logit
 
     If the context is empty, return -inf for the value and 0 for the index
@@ -239,7 +239,7 @@ def arg_best_logit_and_pred(
     :param logits: Logits.  Shape: [batch, None(args), None(context)]
     :type logits: tf.RaggedTensor
     :return: value and index of the best logits.  Shape: [batch, None(arg)]
-    :rtype: tuple[tf.RaggedTensor, tf.RaggedTensor]
+    :rtype: Tuple[tf.RaggedTensor, tf.RaggedTensor]
     """
     # pad context with -inf to make rows uniform
     logits = logits.with_values(logits.values.to_tensor(default_value=-np.inf))  # [batch, None(args), max(context)]
@@ -1015,7 +1015,7 @@ class GlobalArgumentPrediction(LocalArgumentPrediction):
         self,
         logits0: tf.RaggedTensor,  # [batch_dim, (ragged_dim)]
         logits1: tf.RaggedTensor,  # [batch_dim, (ragged_dim)]
-    ) -> tuple[tf.RaggedTensor, tf.RaggedTensor]:  # [batch_dim, (ragged_dim)]
+    ) -> Tuple[tf.RaggedTensor, tf.RaggedTensor]:  # [batch_dim, (ragged_dim)]
 
         # subtract off max value to make stable 
         max_logits0 = tf.expand_dims(tf.reduce_max(logits0, axis=-1), -1)  # [total(args), 1]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version='0.1.0',
     description='graph2tac converts graphs to actions',
     author=' Mirek Olsak, Vasily Pestun, Jason Rute, Fidel I. Schaposnik Massolo',
-    python_requires='>=3.9',
+    python_requires='>=3.8',
     include_package_data=True,
     entry_points={'console_scripts':
                   [
@@ -29,7 +29,7 @@ setup(
         'psutil',
         'pyyaml',
         'graphviz',
-        'pytactician @ git+https://git@github.com/coq-tactician/coq-tactician-reinforce@623952029b0b5e997c08634ba09bb549a0015a0a',
+        'pytactician @ git+https://git@github.com/coq-tactician/coq-tactician-reinforce@ab9a090aee8d7e4afb5fdd2a043aed007f7bdc4c',
         'pytest',
     ]
 )

--- a/split/stats.py
+++ b/split/stats.py
@@ -5,6 +5,7 @@ import yaml
 from dataclasses import dataclass
 import random
 import sys
+from typing import Dict
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -12,9 +13,9 @@ import numpy as np
 
 @dataclass
 class BasicStats:
-    dataset_to_num_thms : dict[str,int]
-    dataset_to_num_proofstates : dict[str,int]
-    dataset_to_deps : dict[str,list[str]]
+    dataset_to_num_thms : Dict[str,int]
+    dataset_to_num_proofstates : Dict[str,int]
+    dataset_to_deps : Dict[str, List[str]]
 
 def compute_basic_stats():
     dataset_path = Path("/home/olsak/datasets_coq/v15-opam-coq8.11-partial/dataset")

--- a/tests/integration/pipeline.py
+++ b/tests/integration/pipeline.py
@@ -10,7 +10,7 @@ import shutil
 import sys
 from unittest.mock import patch
 import tensorflow as tf
-from typing import Any
+from typing import Any, Union
 import warnings
 import yaml
 
@@ -124,7 +124,7 @@ class ExpectedResults:
         return expected_results
 
     @classmethod
-    def approximate(cls, results: dict | list | float | Any, rel_error_tolerance: float) -> dict | list | float | Any:
+    def approximate(cls, results: Union[dict, list, float, Any], rel_error_tolerance: float) -> Union[dict, list, float, Any]:
         """Recursively go through JSON compatible object and replace floats with pytest.approx"""
         if isinstance(results, dict):
             return {k : cls.approximate(v, rel_error_tolerance) for k,v in results.items()}

--- a/tests/integration/pipeline.py
+++ b/tests/integration/pipeline.py
@@ -10,7 +10,7 @@ import shutil
 import sys
 from unittest.mock import patch
 import tensorflow as tf
-from typing import Any, Union
+from typing import Any, Union, List, Tuple
 import warnings
 import yaml
 
@@ -36,11 +36,11 @@ class ParamSets:
             raise Exception("Test parameter directory param_dir not properly configured.")
     
     @staticmethod
-    def _param_train(param_dir: Path) -> tuple[str, str]:
+    def _param_train(param_dir: Path) -> Tuple[str, str]:
         return (param_dir.parent.parent.name, param_dir.name)
     
     @staticmethod
-    def _param_predict_server(param_dir: Path) -> tuple[str, str, str]:
+    def _param_predict_server(param_dir: Path) -> Tuple[str, str, str]:
         # find where to get the trained model from
         with (param_dir / "dependencies.yml").open("r") as f:
             dependencies = yaml.safe_load(f)
@@ -51,7 +51,7 @@ class ParamSets:
         return (data_param, train_param, predict_server_param)
     
     @classmethod
-    def params_for_step(cls, pipeline_step: str) -> list[tuple]:
+    def params_for_step(cls, pipeline_step: str) -> List[tuple]:
         if pipeline_step == "predict_server":
             return sorted([
                 cls._param_predict_server(d)
@@ -162,7 +162,7 @@ class ExpectedResults:
 
 class Pipeline:
     @staticmethod
-    def _run_tfgnn_training(tmp_path: Path, data_dir: Path, params_dir: Path) -> tuple[dict, Path]:
+    def _run_tfgnn_training(tmp_path: Path, data_dir: Path, params_dir: Path) -> Tuple[dict, Path]:
         """Run training and return results for comparison"""
         import graph2tac.tfgnn.train  # put import here so it doesn't break other tests if it crashes
 
@@ -185,7 +185,7 @@ class Pipeline:
         return results, model_dir
 
     @staticmethod
-    def _run_hmodel_training(tmp_path: Path, data_dir: Path, params_dir: Path) -> tuple[dict, Path]:
+    def _run_hmodel_training(tmp_path: Path, data_dir: Path, params_dir: Path) -> Tuple[dict, Path]:
         """Run training and return results for comparison"""
         import graph2tac.loader.hmodel  # put import here so it doesn't break other tests if it crashes
 
@@ -219,7 +219,7 @@ class Pipeline:
         return data, model_dir
 
     @classmethod
-    def _run_training(cls, tmp_path: Path, data_dir: Path, params_dir: Path) -> tuple[dict, Path]:
+    def _run_training(cls, tmp_path: Path, data_dir: Path, params_dir: Path) -> Tuple[dict, Path]:
         training_type = ParamSets.get_pipeline_step(params_dir)
         if training_type == "hmodel":
             return cls._run_hmodel_training(tmp_path=tmp_path, data_dir=data_dir, params_dir=params_dir)
@@ -229,7 +229,7 @@ class Pipeline:
             raise ValueError(f"Unexpected value for training_type: {training_type}")
 
     @classmethod
-    def run_training(cls, tmp_path: Path, data_dir: Path, params_dir: Path, cache: pytest.Cache, use_cached_results: bool = False, retrain: bool = False) -> tuple[dict, Path]:
+    def run_training(cls, tmp_path: Path, data_dir: Path, params_dir: Path, cache: pytest.Cache, use_cached_results: bool = False, retrain: bool = False) -> Tuple[dict, Path]:
         # check for saved pretrained models
         if (params_dir / "model").exists():
             pretrained_model_dir = params_dir / "model"


### PR DESCRIPTION
This removes some uses of 3.9 and 3.10 features to support python 3.8.  Supporting Python 3.11 would require messing with the versions of tensorflow and/or tensorflow_gnn, so I put it off.

The tests still pass.  (Well except for the hmodel test that has been broken for a long time. 😄  I should fix that soon.)